### PR TITLE
Fix typos in Settings dialog

### DIFF
--- a/src/ConEmu/ConEmu.rc
+++ b/src/ConEmu/ConEmu.rc
@@ -837,9 +837,9 @@ BEGIN
     PUSHBUTTON      "...",bGotoEditorCmd,301,27,16,12
     LTEXT           "Available macros: ‘%1’ - line number, ‘%2’ - column number\n‘%3’ - C:\\Path\\File, ‘%4’ - C:/Path/File, ‘%5’ - /C/Path/File\nUse ‘#’ prefix to run editor outside of ConEmu",stGotoEditorCmdHelp,13,44,281,24
     GROUPBOX        "Highlight rows/columns",IDC_STATIC,4,80,319,43
-    CONTROL         "Hightlight whole row under mouse cursor",cbHighlightMouseRow,
+    CONTROL         "Highlight whole row under mouse cursor",cbHighlightMouseRow,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,94,305,8
-    CONTROL         "Hightlight whole column under mouse cursor",cbHighlightMouseCol,
+    CONTROL         "Highlight whole column under mouse cursor",cbHighlightMouseCol,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,107,305,8
 END
 


### PR DESCRIPTION
In Settings > Keys & Macro > Highlight, change "Hightlight" to "Highlight".
