### PR TITLE
Default task 'Git bash' should have a nice looking (default) icon

### DIFF
--- a/src/ConEmu/OptionsFast.cpp
+++ b/src/ConEmu/OptionsFast.cpp
@@ -747,7 +747,12 @@ void CreateDefaultTasks(bool bForceAdd /*= false*/)
 	//{L"CygWin mintty", L"\\CygWin\\bin\\mintty.exe", L" -"},
 	CreateDefaultTask(szConEmuDrive, iCreatIdx, L"MinGW bash",  L" --login -i", L"set CHERE_INVOKING=1 & ", NULL, L"\\MinGW\\msys\\1.0\\bin\\sh.exe", NULL);
 	//{L"MinGW mintty", L"\\MinGW\\msys\\1.0\\bin\\mintty.exe", L" -"},
-	CreateDefaultTask(szConEmuDrive, iCreatIdx, L"Git bash", L" --login -i", NULL, NULL,
+	#ifdef _WIN64
+	wchar_t gitBashIconPrefix[] = L"\"-new_console:C:%ProgramFiles(x86)%\\Git\\etc\\git.ico\" ";
+	#else
+	wchar_t gitBashIconPrefix[] = L"\"-new_console:C:%ProgramFiles%\\Git\\etc\\git.ico\" ";
+	#endif
+	CreateDefaultTask(szConEmuDrive, iCreatIdx, L"Git bash", L" --login -i", gitBashIconPrefix, NULL,
 		L"%ProgramFiles%\\Git\\bin\\sh.exe", L"%ProgramW6432%\\Git\\bin\\sh.exe",
 		#ifdef _WIN64
 		L"%ProgramFiles(x86)%\\Git\\bin\\sh.exe",


### PR DESCRIPTION
Hi, 

think the default configuration for task "Git bash" should have an icon.
This looks way nicer and the icon is already provided by MSYSGIT installation.

It would be a please for me, if you think the same and accept this pull request.

Feedback is welcome.

Best regards
Martin
