### PR TITLE
Fixed couple of bugs in clink integration

### DIFF
--- a/src/ConEmuHk/ConEmuHk12.vcxproj
+++ b/src/ConEmuHk/ConEmuHk12.vcxproj
@@ -439,6 +439,12 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <StringPooling>true</StringPooling>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -469,6 +475,11 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <StringPooling>true</StringPooling>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/src/ConEmuHk/ConEmuHooks.cpp
+++ b/src/ConEmuHk/ConEmuHooks.cpp
@@ -4230,14 +4230,34 @@ bool InitializeClink()
 	//return (gpfnClinkReadLine != NULL);
 }
 
+static bool IsInteractive()
+{
+	const wchar_t* const cmdLine = ::GetCommandLineW();
+	if (!cmdLine)
+	{
+		return true;	// can't know - assume it is
+	}
+
+	const wchar_t* pos = cmdLine;
+	while ((pos = wcschr(pos, L'/')) != nullptr)
+	{
+		switch (towlower(pos[1]))
+		{
+		case L'k':	return true;	// /k - execute and remain working
+		case L'c':	return false;	// /c - execute and exit
+		}
+		++pos;
+	}
+
+	return true;
+}
+
 // cmd.exe only!
 LONG WINAPI OnRegQueryValueExW(HKEY hKey, LPCWSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData)
 {
 	typedef LONG (WINAPI* OnRegQueryValueExW_t)(HKEY hKey, LPCWSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData);
 	ORIGINALFASTEX(RegQueryValueExW,NULL);
-	//BOOL bMainThread = TRUE; // Does not care
 	LONG lRc = -1;
-	bool bNeedAppendClink = false;
 
 	if (gbIsCmdProcess && hKey && lpValueName)
 	{
@@ -4261,78 +4281,79 @@ LONG WINAPI OnRegQueryValueExW(HKEY hKey, LPCWSTR lpValueName, LPDWORD lpReserve
 			}
 			if (gbAllowClinkUsage && gszClinkCmdLine && lstrcmpi(lpValueName, L"AutoRun") == 0)
 			{
-
-				// Is already loaded?
-				HMODULE hClink = GetModuleHandle(WIN3264TEST(L"clink_dll_x86.dll",L"clink_dll_x64.dll"));
-				if (hClink == NULL)
+				if (IsInteractive())
 				{
-					// May be it is set up itself?
-					typedef LONG (WINAPI* RegOpenKeyEx_t)(HKEY hKey, LPCWSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult);
-					typedef LONG (WINAPI* RegCloseKey_t)(HKEY hKey);
-					HMODULE hAdvApi = LoadLibrary(L"AdvApi32.dll");
-					if (hAdvApi)
+					// Is already loaded?
+					HMODULE hClink = GetModuleHandle(WIN3264TEST(L"clink_dll_x86.dll",L"clink_dll_x64.dll"));
+					if (hClink == NULL)
 					{
-						RegOpenKeyEx_t _RegOpenKeyEx = (RegOpenKeyEx_t)GetProcAddress(hAdvApi, "RegOpenKeyExW");
-						RegCloseKey_t  _RegCloseKey  = (RegCloseKey_t)GetProcAddress(hAdvApi, "RegCloseKey");
-						if (_RegOpenKeyEx && _RegCloseKey)
+						// May be it is set up itself?
+						typedef LONG (WINAPI* RegOpenKeyEx_t)(HKEY hKey, LPCWSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult);
+						typedef LONG (WINAPI* RegCloseKey_t)(HKEY hKey);
+						HMODULE hAdvApi = LoadLibrary(L"AdvApi32.dll");
+						if (hAdvApi)
 						{
-							const DWORD cchMax = 0x3FF0;
-							const DWORD cbMax = cchMax*2;
-							wchar_t* pszCmd = (wchar_t*)malloc(cbMax);
-							if (pszCmd)
+							RegOpenKeyEx_t _RegOpenKeyEx = (RegOpenKeyEx_t)GetProcAddress(hAdvApi, "RegOpenKeyExW");
+							RegCloseKey_t  _RegCloseKey  = (RegCloseKey_t)GetProcAddress(hAdvApi, "RegCloseKey");
+							if (_RegOpenKeyEx && _RegCloseKey)
 							{
-								DWORD cbSize;
-								bool bClinkInstalled = false;
-								for (int i = 0; i <= 1 && !bClinkInstalled; i++)
+								const DWORD cchMax = 0x3FF0;
+								const DWORD cbMax = cchMax*2;
+								wchar_t* pszCmd = (wchar_t*)malloc(cbMax);
+								if (pszCmd)
 								{
-									HKEY hk;
-									if (_RegOpenKeyEx(i?HKEY_LOCAL_MACHINE:HKEY_CURRENT_USER, L"Software\\Microsoft\\Command Processor", 0, KEY_READ, &hk))
-										continue;
-									if (!F(RegQueryValueExW)(hk, lpValueName, NULL, NULL, (LPBYTE)pszCmd, &(cbSize = cbMax))
-										&& (cbSize+2) < cbMax)
+									DWORD cbSize;
+									bool bClinkInstalled = false;
+									for (int i = 0; i <= 1 && !bClinkInstalled; i++)
 									{
-										cbSize /= 2; pszCmd[cbSize] = 0;
-										CharLowerBuffW(pszCmd, cbSize);
-										if (wcsstr(pszCmd, L"\\clink.bat"))
-											bClinkInstalled = true;
+										HKEY hk;
+										if (_RegOpenKeyEx(i?HKEY_LOCAL_MACHINE:HKEY_CURRENT_USER, L"Software\\Microsoft\\Command Processor", 0, KEY_READ, &hk))
+											continue;
+										if (!F(RegQueryValueExW)(hk, lpValueName, NULL, NULL, (LPBYTE)pszCmd, &(cbSize = cbMax))
+											&& (cbSize+2) < cbMax)
+										{
+											cbSize /= 2; pszCmd[cbSize] = 0;
+											CharLowerBuffW(pszCmd, cbSize);
+											if (wcsstr(pszCmd, L"\\clink.bat"))
+												bClinkInstalled = true;
+										}
+										_RegCloseKey(hk);
 									}
-									_RegCloseKey(hk);
-								}
-								// Not installed via "Autorun"
-								if (!bClinkInstalled)
-								{
-									bNeedAppendClink = true;
-
-									int iLen = lstrlen(gszClinkCmdLine);
-									_wcscpy_c(pszCmd, cchMax, gszClinkCmdLine);
-									_wcscpy_c(pszCmd+iLen, cchMax-iLen, L" & "); // conveyer next command indifferent to %errorlevel%
-
-									cbSize = cbMax - (iLen + 3)*sizeof(*pszCmd);
-									if (F(RegQueryValueExW)(hKey, lpValueName, NULL, NULL, (LPBYTE)pszCmd, &(cbSize = cbMax))
-										|| (pszCmd[iLen+3] == 0))
+									// Not installed via "Autorun"
+									if (!bClinkInstalled)
 									{
-										pszCmd[iLen] = 0; // There is no self value in registry
-									}
-									cbSize = (lstrlen(pszCmd)+1)*sizeof(*pszCmd);
+										int iLen = lstrlen(gszClinkCmdLine);
+										_wcscpy_c(pszCmd, cchMax, gszClinkCmdLine);
+										_wcscpy_c(pszCmd+iLen, cchMax-iLen, L" & "); // conveyer next command indifferent to %errorlevel%
 
-									// Return
-									lRc = 0;
-									if (lpData && lpcbData)
-									{
-										if (*lpcbData < cbSize)
-											lRc = ERROR_MORE_DATA;
-										else
-											_wcscpy_c((wchar_t*)lpData, (*lpcbData)/2, pszCmd);
+										cbSize = cbMax - (iLen + 3)*sizeof(*pszCmd);
+										if (F(RegQueryValueExW)(hKey, lpValueName, NULL, NULL, (LPBYTE)(pszCmd + iLen + 3), &cbSize)
+											|| (pszCmd[iLen+3] == 0))
+										{
+											pszCmd[iLen] = 0; // There is no self value in registry
+										}
+										cbSize = (lstrlen(pszCmd)+1)*sizeof(*pszCmd);
+
+										// Return
+										lRc = 0;
+										if (lpData && lpcbData)
+										{
+											if (*lpcbData < cbSize)
+												lRc = ERROR_MORE_DATA;
+											else
+												_wcscpy_c((wchar_t*)lpData, (*lpcbData)/2, pszCmd);
+										}
+										if (lpcbData)
+											*lpcbData = cbSize;
+										free(pszCmd);
+										FreeLibrary(hAdvApi);
+										goto wrap;
 									}
-									if (lpcbData)
-										*lpcbData = cbSize;
 									free(pszCmd);
-									goto wrap;
 								}
-								free(pszCmd);
 							}
+							FreeLibrary(hAdvApi);
 						}
-						FreeLibrary(hAdvApi);
 					}
 				}
 			}

--- a/src/ConEmuHk/Entry.cpp
+++ b/src/ConEmuHk/Entry.cpp
@@ -888,10 +888,6 @@ DWORD WINAPI DllStart(LPVOID /*apParm*/)
 	{
 		gbIsMinTtyProcess = true;
 	}
-	else if (lstrcmpi(gsExeName, L"notepad.exe") == 0)
-	{
-		//_ASSERTE(FALSE && "Notepad.exe started!");
-	}
 	else if (IsVsNetHostExe(pszName)) // "*.vshost.exe", "*" may be long, so we use pszName instead of limited gsExeName
 	{
 		gbIsNetVsHost = true;


### PR DESCRIPTION
1. Don't start clink if cmd is started just for single command execution
2. Fixed incorrect buffer address passed when getting AutoRun reg key
value
3. Small improvements for build settings in VS12 project

Original clink starter code has exactly the same check - don't inject clink if cmd was started with /c switch. ConEmu can do this check earlier, so it won't launch clink process. This speeds up many systems built on top of .cmd files a lot
E.g., all tests at my work now pass in 3m30s, down from 5m30s before the fix, and only 2s slower than if run outside of ConEmu and without clink.
