### PR TITLE
Fix hDbg opening in ConsoleMain.cpp

### DIFF
--- a/src/ConEmuCD/ConsoleMain.cpp
+++ b/src/ConEmuCD/ConsoleMain.cpp
@@ -892,7 +892,7 @@ int __stdcall ConsoleMain2(int anWorkMode/*0-Server&ComSpec,1-AltServer,2-Reserv
 	BOOL lbDbgWrite; DWORD nDbgWrite; HANDLE hDbg; char szDbgString[255], szHandles[128];
 	sprintf(szDbgString, "ConEmuC: PID=%u", GetCurrentProcessId());
 	MessageBoxA(0, GetCommandLineA(), szDbgString, MB_SYSTEMMODAL);
-	hDbg = CreateFile(L"CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_READ,
+	hDbg = CreateFile(L"CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
 	                  0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
 	sprintf(szHandles, "STD_OUTPUT_HANDLE(0x%08X) STD_ERROR_HANDLE(0x%08X) CONOUT$(0x%08X)",
 	        (DWORD)GetStdHandle(STD_OUTPUT_HANDLE), (DWORD)GetStdHandle(STD_ERROR_HANDLE), (DWORD)hDbg);


### PR DESCRIPTION
`FILE_SHARE_READ | FILE_SHARE_READ` is obviously incorrect, I suppose `FILE_SHARE_READ | FILE_SHARE_WRITE` is the correct share mode.
*******
I was just passing by looking for a cause why `CreateFile("CONOUT$", ...` doesn't work for me when I saw this typo (or maybe result of copy&paste). Thought you might want to have this fixed.