### PR TITLE
Problems with Vim in Windows cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Don't start cygwin inside a cmd console!
 Go to ConEmu Settings -> Startup -> Tasks and add a new task.
 In the 'Commands' TextBox add:
 C:\cygwin64\bin\mintty.exe -e "/cygwin.bat"
+
 Replace 'C:\cygwin64' with your cygwin path.
 
 To start mintty cygwin:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 If you use Vim (command line version) in Windows and you have problems to scroll
 by using the mouse wheel, you can try this Fork.
 
-When Vim is running inside this version of ConEmu
-the mouse wheel events vk_scroll_down and vk_scroll_up will be replaced with vk_f6 and vk_f7.
 
 You have to add following to your vimrc file:
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ ConEmu toolbar ->
 "Create new console"(small arrow right next to the green button) 
 and select {your mintty task}
 
+dont forge to ':set mouse=a' in your remote vimrc
+
 Have fun
 
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ConEmu toolbar ->
 "Create new console"(small arrow right next to the green button) 
 and select {your mintty task}
 
-dont forge to ':set mouse=a' in your remote vimrc
+Dont forge to ':set mouse=a' in your remote vimrc
 
 Have fun
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 ## About this Fork
 
-If you have problems with Vim (command line version) in Windows 
-when you try to scroll inside Vim by using the mouse wheel you can try this Fork.
+If you have problems with Vim (command line version) in Windows to scroll inside Vim 
+by using the mouse wheel, you can try this Fork.
 
-When Vim is running inside this version of ConEmu:
-The mouse wheel events vk_scroll_down and vk_scroll_up will be replaced with vk_f6 and vk_f7.
+When Vim is running inside this version of ConEmu
+the mouse wheel events vk_scroll_down and vk_scroll_up will be replaced with vk_f6 and vk_f7.
 
-You have to add following to your vimrc file 
+You have to add following to your vimrc file:
+
 <b>
 if !has("gui_running")
     "set mouse=a
@@ -16,7 +17,8 @@ if !has("gui_running")
     nnoremap <F7> <C-e>
 endif</b>
 
-
+Thats all. 
+Now you should be able to scroll inside Vim just like you do it in GVim.
 
 
 ## About ConEmu

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ the mouse wheel events vk_scroll_down and vk_scroll_up will be replaced with vk_
 
 You have to add following to your vimrc file:
 
-<b>
+```
 if !has("gui_running")
     "set mouse=a
     inoremap <F6> <C-x><C-Y>
     inoremap <F7> <C-x><C-e>
     nnoremap <F6> <C-Y>
     nnoremap <F7> <C-e>
-endif</b>
+endif
+```
 
 Thats all. 
 Now you should be able to scroll inside Vim just like you do it in GVim.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+## About this Fork
+
+If you have problems with Vim (command line version) in Windows 
+when you try to scroll inside Vim by using the mouse wheel you can try this Fork.
+
+When Vim is running inside this version of ConEmu:
+The mouse wheel events vk_scroll_down and vk_scroll_up will be replaced with vk_f6 and vk_f7.
+
+You have to add following to your vimrc file 
+<b>
+if !has("gui_running")
+    "set mouse=a
+    inoremap <F6> <C-x><C-Y>
+    inoremap <F7> <C-x><C-e>
+    nnoremap <F6> <C-Y>
+    nnoremap <F7> <C-e>
+endif</b>
+
+
+
+
 ## About ConEmu
 ConEmu-Maximus5 is a Windows console emulator with tabs, which represents
 multiple consoles as one customizable GUI window with various features.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ if !has("gui_running")
     inoremap <F7> <C-x><C-e>
     nnoremap <F6> <C-Y>
     nnoremap <F7> <C-e>
+
+    snoremap <F6> <C-Y>
+    snoremap <F7> <C-e>
 endif
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,24 +30,6 @@ Now you should be able to scroll inside Vim just like you do it in GVim.
 
 ________
 
-For SSH connections I recommend to use the 'mintty cygwin' shell.
-Don't start cygwin inside a cmd console! 
-
-Go to ConEmu Settings -> Startup -> Tasks and add a new task.
-In the 'Commands' TextBox add:
-C:\cygwin64\bin\mintty.exe -e "/cygwin.bat"
-
-Replace 'C:\cygwin64' with your cygwin path.
-
-To start mintty cygwin:
-ConEmu toolbar -> 
-"Create new console"(small arrow right next to the green button) 
-and select {your mintty task}
-
-Dont forge to ':set mouse=a' in your remote vimrc
-
-Have fun
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ if !has("gui_running")
 endif
 ```
 
-Thats all. 
+<b>Thats all.</b 
 Now you should be able to scroll inside Vim just like you do it in GVim.
+
 
 For SSH connections I recommend to use the 'mintty cygwin' shell.
 Don't start cygwin inside a cmd console! 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ ConEmu toolbar ->
 "Create new console"(small arrow right next to the green button) 
 and select {your mintty task}
 
+Have fun
 
 
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ if !has("gui_running")
 endif
 ```
 
-<b>Thats all.</b 
+Thats all.
 Now you should be able to scroll inside Vim just like you do it in GVim.
 
+________
 
 For SSH connections I recommend to use the 'mintty cygwin' shell.
 Don't start cygwin inside a cmd console! 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You have to add following to your vimrc file:
 
 ```
 if !has("gui_running")
-    "set mouse=a
+    set mouse=a
     inoremap <F6> <C-x><C-Y>
     inoremap <F7> <C-x><C-e>
     nnoremap <F6> <C-Y>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you use Vim (command line version) in Windows and you have problems to scroll
 by using the mouse wheel, you can try this ConEmu Fork.
 
 
-You have to add following to your vimrc file:
+You have to add following lines to your vimrc file:
 
 ```
 if !has("gui_running")

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Thats all.
 Now you should be able to scroll inside Vim just like you do it in GVim.
 
 
+
+
+
+
+
+
+
+
+
+
+
+
 ## About ConEmu
 ConEmu-Maximus5 is a Windows console emulator with tabs, which represents
 multiple consoles as one customizable GUI window with various features.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Download binary for 32 and 64bit Windows: (http://xumbu.org/downloads/opensource
 
 ## About this Fork
 
-If you use Vim (command line version) in Windows and you have problems to scroll
+If you use Vim in Windows cmd.exe and you have problems to scroll
 by using the mouse wheel, you can try this ConEmu Fork.
 
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,18 @@ endif
 Thats all. 
 Now you should be able to scroll inside Vim just like you do it in GVim.
 
+For SSH connections I recommend to use the 'mintty cygwin' shell.
+Don't start cygwin inside a cmd console! 
 
+Go to ConEmu Settings -> Startup -> Tasks and add a new task.
+In the 'Commands' TextBox add:
+C:\cygwin64\bin\mintty.exe -e "/cygwin.bat"
+Replace 'C:\cygwin64' with your cygwin path.
 
-
-
-
-
+To start mintty cygwin:
+ConEmu toolbar -> 
+"Create new console"(small arrow right next to the green button) 
+and select {your mintty task}
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ if !has("gui_running")
 
     snoremap <F6> <C-Y>
     snoremap <F7> <C-e>
+   
+    vnoremap <F6> <C-Y> 
+    vnoremap <F7> <C-e  
 endif
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## About this Fork
 
 If you use Vim (command line version) in Windows and you have problems to scroll
-by using the mouse wheel, you can try this Fork.
+by using the mouse wheel, you can try this ConEmu Fork.
 
 
 You have to add following to your vimrc file:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Download binary for 32 and 64bit Windows: (http://xumbu.org/downloads/opensource/prebuild/ConEmu_VimScrollPack.zip)
+
+
 ## About this Fork
 
 If you use Vim (command line version) in Windows and you have problems to scroll

--- a/src/ConEmu/ConEmu.cpp
+++ b/src/ConEmu/ConEmu.cpp
@@ -49,6 +49,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ShObjIdl_Part.h"
 //#include <lm.h>
 //#include "../common/ConEmuCheck.h"
+#include <Psapi.h> //needed for Vim ScrollFix
 
 #include "../common/execute.h"
 #include "../common/MArray.h"
@@ -10118,6 +10119,46 @@ LRESULT CConEmuMain::OnMouse(HWND hWnd, UINT messg, WPARAM wParam, LPARAM lParam
 				VCon->RCon()->PostConsoleMessage(hGuiChild, messg, wParam, lParam);
 				return 0;
 			}
+
+			//ckech if vim is running
+			DWORD currentProcess = pRCon->GetRunningPID();
+			if (currentProcess)
+			{
+				HANDLE currentProcessHandle = OpenProcess(
+					PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+					FALSE,
+					currentProcess
+					);
+
+				TCHAR Buffer[MAX_PATH];
+				if (currentProcessHandle)
+				{
+					TCHAR vimBaseName[] = _T("vim.exe");
+					if (GetModuleBaseName(currentProcessHandle, NULL, Buffer, MAX_PATH) > 0) //vim is running  -> send F6 and F7 instead of mouse wheel events 
+					{
+						if (!_tcscmp(Buffer, vimBaseName))
+						{
+							short scrollValue = (int)(short)HIWORD(wParam);
+
+							int i;
+							int scrollSize = 3; //gvim default
+							for (i = 0; i < scrollSize; i++)
+							{
+								if (scrollValue > 0)
+								{
+									VCon->RCon()->PostKeyPress(VK_F6, 0, 0);
+									VCon->RCon()->PostKeyUp(VK_F6, 0, 0);
+								}
+								else if (scrollValue < 0)
+								{
+									VCon->RCon()->PostKeyPress(VK_F7, 0, 0);
+									VCon->RCon()->PostKeyUp(VK_F7, 0, 0);
+								}
+							}
+						}
+					}
+				}
+			}//
 		}
 	}
 


### PR DESCRIPTION
I had problems with (official!) Vim in Windows when I used the command line version.
I wasn't able to scroll using the mouse wheel.

So it is not a ConEmu problem but a normal behavior in Windows (or Vim for Windows)

I had the same problem in different  Vim and Windows versions (Windows 7/8/10), so I guess that I am not the only one who noticed that.

Here is a simple "fix" I just made for myself. 