### PR TITLE
"cd" to focused Explorer window's directory path

### DIFF
--- a/src/ConEmu/ConEmu.cpp
+++ b/src/ConEmu/ConEmu.cpp
@@ -180,6 +180,7 @@ gRegisteredHotKeys[] = {
 	{vkMinimizeRestor2},
 	{vkGlobalRestore},
 	{vkForceFullScreen},
+	{vkCdExplorerPath},
 };
 
 namespace ConEmuMsgLogger
@@ -4359,6 +4360,9 @@ void CConEmuMain::OnWmHotkey(WPARAM wParam)
 					break;
 				case vkForceFullScreen:
 					DoForcedFullScreen(true);
+					break;
+				case vkCdExplorerPath:
+					DoCdExplorerPath();
 					break;
 				}
 				break;

--- a/src/ConEmu/ConEmu.rc2
+++ b/src/ConEmu/ConEmu.rc2
@@ -355,6 +355,7 @@ BEGIN
 	vkMultiNextShift        "Switch previous console"
 	vkMultiPause            "Pause current console"
 	vkMultiRecreate         "Recreate active console"
+	vkCdExplorerPath        "Send cd to focused Explorer path window"
 	vkPasteCygwin           "Paste path from clipboard in unix format"
 	vkPasteDirectory        "Choose and paste folder path"
 	vkPasteFilePath         "Choose and paste file pathname"

--- a/src/ConEmu/ConEmuCtrl.cpp
+++ b/src/ConEmu/ConEmuCtrl.cpp
@@ -1301,6 +1301,15 @@ bool CConEmuCtrl::key_AlwaysOnTop(const ConEmuChord& VkState, bool TestOnly, con
 	return true;
 }
 
+bool CConEmuCtrl::key_SendCDToExplorerPath(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon)
+{
+	if (TestOnly)
+		return true;
+
+	gpConEmu->DoCdExplorerPath();
+	return true;
+}
+
 bool CConEmuCtrl::key_PasteText(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon)
 {
 	if (!pRCon || pRCon->isFar())

--- a/src/ConEmu/ConEmuCtrl.h
+++ b/src/ConEmu/ConEmuCtrl.h
@@ -146,6 +146,7 @@ public:
 	static bool WINAPI key_MoveTabLeft(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_MoveTabRight(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	// Clipboard
+	static bool WINAPI key_SendCDToExplorerPath(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_PasteText(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_PasteTextAllApp(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_PasteFirstLine(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);

--- a/src/ConEmu/ConEmuSize.cpp
+++ b/src/ConEmu/ConEmuSize.cpp
@@ -6290,9 +6290,9 @@ static TCHAR* getFocusedExplorerWindowPath()
 
 	return ret;
 
-#undef CHECK_OUTER_FAIL
-#undef CHECK_FAIL
-#undef RELEASE
+#undef FE_CHECK_OUTER_FAIL
+#undef FE_CHECK_FAIL
+#undef FE_RELEASE
 }
 
 void CConEmuSize::DoCdExplorerPath()

--- a/src/ConEmu/ConEmuSize.cpp
+++ b/src/ConEmu/ConEmuSize.cpp
@@ -6216,70 +6216,83 @@ void CConEmuSize::DoForcedFullScreen(bool bSet /*= true*/)
 
 static TCHAR* getFocusedExplorerWindowPath()
 {
+#define FE_CHECK_OUTER_FAIL(statement) \
+	if (!SUCCEEDED(statement)) goto outer_fail;
+
+#define FE_CHECK_FAIL(statement) \
+	if (!SUCCEEDED(statement)) goto fail;
+
+#define FE_RELEASE(hnd) \
+	if (hnd) { hnd->Release(); hnd = NULL; }
+
 	TCHAR g_szPath[MAX_PATH];
 	TCHAR g_szItem[MAX_PATH];
 
 	TCHAR* ret = NULL;
 
+	IShellBrowser *psb = NULL;
+	IShellView *psv = NULL;
+	IFolderView *pfv = NULL;
+	IPersistFolder2 *ppf2 = NULL;
+	IDispatch  *pdisp = NULL;
+	IWebBrowserApp *pwba = NULL;
+	IServiceProvider *psp = NULL;
+	IShellWindows *psw = NULL;
+
+	VARIANT v;
+	HWND hwndWBA;
+	LPITEMIDLIST pidlFolder;
+
+	BOOL fFound = FALSE;
 	HWND hwndFind = GetForegroundWindow();
-	IShellWindows *psw;
-	if (SUCCEEDED(CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_ALL,
-		IID_IShellWindows, (void**)&psw))) {
-		VARIANT v;
-		V_VT(&v) = VT_I4;
-		IDispatch  *pdisp;
-		BOOL fFound = FALSE;
-		for (V_I4(&v) = 0; !fFound && psw->Item(v, &pdisp) == S_OK;
-			V_I4(&v)++) {
-			IWebBrowserApp *pwba;
-			if (SUCCEEDED(pdisp->QueryInterface(IID_IWebBrowserApp, (void**)&pwba))) {
-				HWND hwndWBA;
-				if (SUCCEEDED(pwba->get_HWND((LONG_PTR*)&hwndWBA)) &&
-					hwndWBA == hwndFind) {
-					fFound = TRUE;
-					IServiceProvider *psp;
-					if (SUCCEEDED(pwba->QueryInterface(IID_IServiceProvider, (void**)&psp))) {
-						IShellBrowser *psb;
-						if (SUCCEEDED(psp->QueryService(SID_STopLevelBrowser,
-							IID_IShellBrowser, (void**)&psb))) {
-							IShellView *psv;
-							if (SUCCEEDED(psb->QueryActiveShellView(&psv))) {
-								IFolderView *pfv;
-								if (SUCCEEDED(psv->QueryInterface(IID_IFolderView,
-									(void**)&pfv))) {
-									IPersistFolder2 *ppf2;
-									if (SUCCEEDED(pfv->GetFolder(IID_IPersistFolder2,
-										(void**)&ppf2))) {
-										LPITEMIDLIST pidlFolder;
-										if (SUCCEEDED(ppf2->GetCurFolder(&pidlFolder))) {
-											if (!SHGetPathFromIDList(pidlFolder, g_szPath)) {
-												lstrcpyn(g_szPath, TEXT("<not a directory>"), MAX_PATH);
-											}
 
-											ret = (TCHAR*)malloc(sizeof(TCHAR) * MAX_PATH);
-											memcpy(ret, g_szPath, sizeof(TCHAR) * MAX_PATH);
+	FE_CHECK_OUTER_FAIL(CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_ALL,
+		IID_IShellWindows, (void**)&psw))
 
-											CoTaskMemFree(pidlFolder);
-										}
-										ppf2->Release();
-									}
-									pfv->Release();
-								}
-								psv->Release();
-							}
-							psb->Release();
-						}
-						psp->Release();
-					}
-				}
-				pwba->Release();
-			}
-			pdisp->Release();
-		}
-		psw->Release();
+	V_VT(&v) = VT_I4;
+	for (V_I4(&v) = 0; !fFound && psw->Item(v, &pdisp) == S_OK;
+		V_I4(&v)++) {
+		
+		FE_CHECK_FAIL(pdisp->QueryInterface(IID_IWebBrowserApp, (void**)&pwba))
+		FE_CHECK_FAIL(pwba->get_HWND((LONG_PTR*)&hwndWBA))
+
+		if (hwndWBA != hwndFind)
+			goto fail;
+
+		fFound = TRUE;
+		FE_CHECK_FAIL(pwba->QueryInterface(IID_IServiceProvider, (void**)&psp))
+		FE_CHECK_FAIL(psp->QueryService(SID_STopLevelBrowser, IID_IShellBrowser, (void**)&psb))
+		FE_CHECK_FAIL(psb->QueryActiveShellView(&psv))
+		FE_CHECK_FAIL(psv->QueryInterface(IID_IFolderView, (void**)&pfv))
+		FE_CHECK_FAIL(pfv->GetFolder(IID_IPersistFolder2, (void**)&ppf2))
+		FE_CHECK_FAIL(ppf2->GetCurFolder(&pidlFolder))
+
+		if (!SHGetPathFromIDList(pidlFolder, g_szPath))
+			goto fail;
+
+		ret = (TCHAR*)malloc(sizeof(TCHAR) * MAX_PATH);
+		memcpy(ret, g_szPath, sizeof(TCHAR) * MAX_PATH);
+
+		CoTaskMemFree(pidlFolder);
+
+		fail:
+		FE_RELEASE(ppf2)
+		FE_RELEASE(pfv)
+		FE_RELEASE(psv)
+		FE_RELEASE(psb)
+		FE_RELEASE(psp)
+		FE_RELEASE(pwba)
+		FE_RELEASE(pdisp)
 	}
 
+	outer_fail:
+	FE_RELEASE(psw)
+
 	return ret;
+
+#undef CHECK_OUTER_FAIL
+#undef CHECK_FAIL
+#undef RELEASE
 }
 
 void CConEmuSize::DoCdExplorerPath()

--- a/src/ConEmu/ConEmuSize.h
+++ b/src/ConEmu/ConEmuSize.h
@@ -181,6 +181,7 @@ public:
 	void DoMaximizeRestore();
 	void DoMinimizeRestore(SingleInstanceShowHideType ShowHideType = sih_None);
 	void DoForcedFullScreen(bool bSet = true);
+	void DoCdExplorerPath();
 	void DoAlwaysOnTopSwitch();
 	void DoDesktopModeSwitch();
 

--- a/src/ConEmu/HotkeyList.cpp
+++ b/src/ConEmu/HotkeyList.cpp
@@ -107,8 +107,10 @@ int ConEmuHotKeyList::AllocateHotkeys()
 		;
 	Add(vkGlobalRestore,  chk_Global, NULL,   L"GlobalRestore",         CConEmuCtrl::key_GlobalRestore)
 		;
+	Add(vkCdExplorerPath, chk_Global, NULL,   L"CdExplorerPath",        CConEmuCtrl::key_SendCDToExplorerPath)
+		;
 	Add(vkForceFullScreen,chk_Global, NULL,   L"ForcedFullScreen",      CConEmuCtrl::key_ForcedFullScreen)
-		->SetHotKey(VK_RETURN,VK_CONTROL,VK_LWIN,VK_MENU);
+		->SetHotKey(VK_RETURN, VK_CONTROL, VK_LWIN, VK_MENU);
 	/*
 		-- Добавить chk_Local недостаточно, нужно еще и gActiveOnlyHotKeys обработать
 	*/
@@ -228,7 +230,7 @@ int ConEmuHotKeyList::AllocateHotkeys()
 	Add(vkShowTabsList,   chk_User,  NULL,    L"Multi.ShowTabsList",    CConEmuCtrl::key_ShowTabsList)
 		;
 	Add(vkShowTabsList2,  chk_User,  NULL,    L"Multi.ShowTabsList2",   CConEmuCtrl::key_GuiMacro, false, L"Tabs(8)")
-		->SetHotKey(VK_F12,VK_APPS);
+		->SetHotKey(VK_F12, VK_APPS);
 	Add(vkPasteText,      chk_User,  NULL,    L"ClipboardVkAllLines",   CConEmuCtrl::key_PasteText)
 		->SetHotKey(VK_INSERT,VK_SHIFT);
 	Add(vkPasteFirstLine, chk_User,  NULL,    L"ClipboardVkFirstLine",  CConEmuCtrl::key_PasteFirstLine)
@@ -323,7 +325,7 @@ int ConEmuHotKeyList::AllocateHotkeys()
 	Add(vkPasteDirectory, chk_User,  NULL,    L"PastePathKey",          CConEmuCtrl::key_GuiMacro, false, L"Paste(5)")
 		->SetHotKey('D',VK_CONTROL,VK_SHIFT);
 	Add(vkPasteCygwin,    chk_User,  NULL,    L"PasteCygwinKey",        CConEmuCtrl::key_GuiMacro, false, L"Paste(8)")
-		->SetHotKey(VK_INSERT,VK_APPS);
+		->SetHotKey(VK_INSERT, VK_APPS);
 	/*
 		*** GUI Macros
 	*/

--- a/src/ConEmu/HotkeyList.cpp
+++ b/src/ConEmu/HotkeyList.cpp
@@ -110,7 +110,7 @@ int ConEmuHotKeyList::AllocateHotkeys()
 	Add(vkCdExplorerPath, chk_Global, NULL,   L"CdExplorerPath",        CConEmuCtrl::key_SendCDToExplorerPath)
 		;
 	Add(vkForceFullScreen,chk_Global, NULL,   L"ForcedFullScreen",      CConEmuCtrl::key_ForcedFullScreen)
-		->SetHotKey(VK_RETURN, VK_CONTROL, VK_LWIN, VK_MENU);
+		->SetHotKey(VK_RETURN,VK_CONTROL,VK_LWIN,VK_MENU);
 	/*
 		-- Добавить chk_Local недостаточно, нужно еще и gActiveOnlyHotKeys обработать
 	*/

--- a/src/ConEmu/HotkeyList.cpp
+++ b/src/ConEmu/HotkeyList.cpp
@@ -230,7 +230,7 @@ int ConEmuHotKeyList::AllocateHotkeys()
 	Add(vkShowTabsList,   chk_User,  NULL,    L"Multi.ShowTabsList",    CConEmuCtrl::key_ShowTabsList)
 		;
 	Add(vkShowTabsList2,  chk_User,  NULL,    L"Multi.ShowTabsList2",   CConEmuCtrl::key_GuiMacro, false, L"Tabs(8)")
-		->SetHotKey(VK_F12, VK_APPS);
+		->SetHotKey(VK_F12,VK_APPS);
 	Add(vkPasteText,      chk_User,  NULL,    L"ClipboardVkAllLines",   CConEmuCtrl::key_PasteText)
 		->SetHotKey(VK_INSERT,VK_SHIFT);
 	Add(vkPasteFirstLine, chk_User,  NULL,    L"ClipboardVkFirstLine",  CConEmuCtrl::key_PasteFirstLine)
@@ -325,7 +325,7 @@ int ConEmuHotKeyList::AllocateHotkeys()
 	Add(vkPasteDirectory, chk_User,  NULL,    L"PastePathKey",          CConEmuCtrl::key_GuiMacro, false, L"Paste(5)")
 		->SetHotKey('D',VK_CONTROL,VK_SHIFT);
 	Add(vkPasteCygwin,    chk_User,  NULL,    L"PasteCygwinKey",        CConEmuCtrl::key_GuiMacro, false, L"Paste(8)")
-		->SetHotKey(VK_INSERT, VK_APPS);
+		->SetHotKey(VK_INSERT,VK_APPS);
 	/*
 		*** GUI Macros
 	*/

--- a/src/ConEmu/resource.h
+++ b/src/ConEmu/resource.h
@@ -1154,7 +1154,7 @@
 #define stExtendFonts                   2836
 #define stUnicodeRanges                 2837
 #define cbUnicodeRangesApply            2838
-#define vkCdExplorerPath				3839
+#define vkCdExplorerPath                2839
 #define IDC_STATIC                      -1
 
 // Next default values for new objects

--- a/src/ConEmu/resource.h
+++ b/src/ConEmu/resource.h
@@ -1154,6 +1154,7 @@
 #define stExtendFonts                   2836
 #define stUnicodeRanges                 2837
 #define cbUnicodeRangesApply            2838
+#define vkCdExplorerPath				3839
 #define IDC_STATIC                      -1
 
 // Next default values for new objects


### PR DESCRIPTION
Added a hotkey to automatically "cd" into the path that the focused Explorer window has.

Not sure where to put the massive, ugly getFocusedExplorerWindowPath method.