### PR TITLE
GitShowBranch.cmd: prevent broken expansion in repository check

### DIFF
--- a/Release/ConEmu/GitShowBranch.cmd
+++ b/Release/ConEmu/GitShowBranch.cmd
@@ -150,11 +150,11 @@ goto prepare
 )
 
 rem Firstly check if it is not a git repository
-rem Set "gitbranch" to full contents of %git_out% file
+rem Set "gitbranch" to full contents of %git_err% file
 set /P gitbranch=<"%git_err%"
 rem But we need only first line of it
 set "gitbranch=%gitbranch%"
-if "%gitbranch:~0,16%" == "fatal: Not a git" (
+if "fatal: Not a git" == "%gitbranch:~0,16%" (
 rem echo Not a .git repository
 del "%git_out%">nul
 del "%git_err%">nul


### PR DESCRIPTION
Somehow putting the slice of %gitbranch% first causes cmd.exe to misparse the line and terminate the batch with `( was unexpected at this time.` Reversing the operands seems to make cmd.exe parse correctly.