### PR TITLE
Updated build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ about release stages, distro packets, some warnings and much more...
 
 
 ## Building from sources
-https://github.com/Maximus5/ConEmu/blob/master/src/HowToBuild.txt
+https://github.com/Maximus5/ConEmu/blob/master/src/HowToBuild.md
 
  
 ## Screenshots

--- a/src/HowToBuild.md
+++ b/src/HowToBuild.md
@@ -27,7 +27,7 @@ originally forked from here:
    CE10.sln  Visual C++ 2010
    CE11.sln  Visual C++ 2012
    CE12.sln  Visual C++ 2013
-   CE14.sln  Visual C++ 2014
+   CE14.sln  Visual C++ 2015 (also requires C++ 2013 installed)
 
 2. Visual C++ makefiles (current releases are build with Windows SDK 7.0)
    Example: nmake /F makefile_all_vc


### PR DESCRIPTION
Updated build instructions to indicate VS2013 required for VS2015 builds. 

Also changed file extension so that GitHub renders it with formatting.