### PR TITLE
ConEmu.Core: Missing CmdInit.cmd

### DIFF
--- a/nuget/ConEmu.Core/ConEmu.Core.nuspec
+++ b/nuget/ConEmu.Core/ConEmu.Core.nuspec
@@ -52,5 +52,7 @@ Short list of features:
     <file src="..\..\Release\ConEmu\ConEmuCD64.dll" target="Tools\ConEmu" />
     <file src="..\..\Release\ConEmu\ConEmuHk.dll" target="Tools\ConEmu" />
     <file src="..\..\Release\ConEmu\ConEmuHk64.dll" target="Tools\ConEmu" />
+    <!-- Additional files required to operate terminal features, like running “{cmd}”. -->
+    <file src="..\..\Release\ConEmu\CmdInit.cmd" target="Tools\ConEmu" />
   </files>
 </package>


### PR DESCRIPTION
Starting a terminal control for `{cmd}` gives
```
'P:\External\conemu-inside\bin\Debug\ConEmu\CmdInit.cmd' is not recognized as an internal or external command, 
operable program or batch file.      
                                     
P:\External\conemu-inside\bin\Debug> 
```

So looks like the exes/dlls we've taken into the package is not enough to make it a fully-working terminal. 

What else should we add to make secondary terminal features work?