### PR TITLE
Fix VS2015 Release build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ _*.sln
 
 /gcc
 /Debug
-/Release
 /MinGW
 /Portable_Test
 /ConEmuPortableRarInfo.txt
@@ -45,3 +44,10 @@ help
 x64
 
 /CreateRelease.cmd
+
+Release/**/*.iobj
+Release/**/*.ipdb
+Release/**/*.iobj
+Release/**/*.ipdb
+Release/**/*.exp
+Release/**/*.lib

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,5 @@ x64
 Release/**/*.iobj
 Release/**/*.ipdb
 Release/**/*.iobj
-Release/**/*.ipdb
 Release/**/*.exp
 Release/**/*.lib

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ _*.sln
 
 /gcc
 /Debug
+/Release
 /MinGW
 /Portable_Test
 /ConEmuPortableRarInfo.txt

--- a/src/ConEmuBg/ConEmuBg14.vcxproj
+++ b/src/ConEmuBg/ConEmuBg14.vcxproj
@@ -225,7 +225,6 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>version.lib;libcmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
       <ModuleDefinitionFile>export.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>

--- a/src/ConEmuBg/ConEmuBg14.vcxproj.filters
+++ b/src/ConEmuBg/ConEmuBg14.vcxproj.filters
@@ -48,11 +48,11 @@
     <ClCompile Include="..\common\WThreads.cpp">
       <Filter>0 - Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\common\MStrDup.cpp">
+      <Filter>0 - Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\common\common.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="ConEmuBg.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -87,6 +87,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\common\WThreads.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\Common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\kl_parts.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\MStrDup.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/ConEmuLn/ConEmuLn14.vcxproj
+++ b/src/ConEmuLn/ConEmuLn14.vcxproj
@@ -225,7 +225,6 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>version.lib;libcmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
       <ModuleDefinitionFile>export.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>

--- a/src/ConEmuLn/ConEmuLn14.vcxproj.filters
+++ b/src/ConEmuLn/ConEmuLn14.vcxproj.filters
@@ -47,9 +47,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\common\common.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="ConEmuLn.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -81,6 +78,12 @@
       <Filter>Far-Api</Filter>
     </ClInclude>
     <ClInclude Include="..\common\WThreads.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\Common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\kl_parts.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/ConEmuTh/ConEmuTh14.vcxproj
+++ b/src/ConEmuTh/ConEmuTh14.vcxproj
@@ -225,7 +225,6 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>version.lib;libcmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
       <ModuleDefinitionFile>export.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>

--- a/src/ConEmuTh/ConEmuTh14.vcxproj.filters
+++ b/src/ConEmuTh/ConEmuTh14.vcxproj.filters
@@ -60,9 +60,6 @@
     <ClCompile Include="ConEmuTh2800.cpp">
       <Filter>0 - Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\common\CmdArg.cpp">
-      <Filter>0 - Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\common\CmdLine.cpp">
       <Filter>0 - Source Files</Filter>
     </ClCompile>
@@ -84,6 +81,15 @@
     <ClCompile Include="..\common\WUser.cpp">
       <Filter>0 - Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\common\CEStr.cpp">
+      <Filter>0 - Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\common\HkFunc.cpp">
+      <Filter>0 - Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\common\MStrDup.cpp">
+      <Filter>0 - Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="icon1.ico">
@@ -92,9 +98,6 @@
     <None Include="!ToDo.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\common\common.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="ConEmuTh.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -149,9 +152,6 @@
     <ClInclude Include="..\common\pluginW1900.hpp">
       <Filter>Far-Api</Filter>
     </ClInclude>
-    <ClInclude Include="..\common\CmdArg.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\common\CmdLine.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -171,6 +171,21 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\common\WUser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\CEStr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\Common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\HkFunc.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\kl_parts.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\MStrDup.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Steps to reproduce:

* Clone ConEmu source 1603134
* Install Visual Studio 2015 Community
* Open CE14.sln
* Choose Release|Win32 configuration
* Build solution

Result:

Three of the Far.* projects fail to link with errors like __memmove unresolved, etc.

Cause:

Those projects have the /NODEFAULTLIBS option set but libraries besides libcmt.lib are needed to link.
