### PR TITLE
Text flow to next line broken when ESC]9;8; is used #563

### DIFF
--- a/Release/ConEmu/CmdInit.cmd
+++ b/Release/ConEmu/CmdInit.cmd
@@ -30,7 +30,7 @@ if "%ConEmuIsAdmin%" == "ADMIN" (
 )
 
 rem Finally reset color and add space
-set ConEmuPrompt3=$E[m$S$E]9;12$E\
+set ConEmuPrompt3=$S$E[0;37;40m
 
 if /I "%~1" == "/git" goto git
 if /I "%~1" == "-git" goto git


### PR DESCRIPTION
I have been playing with different PROMPT options and replacing the line set ConEmuPrompt3=$E[m$S$E]9;12$E\ with set ConEmuPrompt3=$S$E[0;37;40m in the ConEmu\CmdInit.cmd fixes the issue with clink. Now long line properly wraps.