### PR TITLE
WinPosSize: fix changing size without changing position 

### DIFF
--- a/src/ConEmu/ConEmuApp.cpp
+++ b/src/ConEmu/ConEmuApp.cpp
@@ -623,7 +623,7 @@ bool IntFromString(int& rnValue, LPCWSTR asValue, int anBase /*= 10*/, LPCWSTR* 
 	}
 
 	if (rsEnd) *rsEnd = pszEnd;
-	return true;
+	return bOk;
 }
 
 bool GetDlgItemSigned(HWND hDlg, WORD nID, int& nValue, int nMin /*= 0*/, int nMax /*= 0*/)


### PR DESCRIPTION
This fixes a bug in the function that SetWinPosSize uses to parse the position args (IntFromString).

With this fix, you should now be able to use, eg:
  ConEmuC.exe -guimacro WindowPosSize keep keep 120 24
to change the size to 120x24 while keeping the position unchanged.
Note that 'keep' can be anything that does not parse into an int.
