### PR TITLE
Better handling of per-monitor DPI changes

### DIFF
--- a/src/ConEmu/ConEmu.cpp
+++ b/src/ConEmu/ConEmu.cpp
@@ -176,24 +176,6 @@ const wchar_t* gsWhatsNew    = CEWHATSNEW;    //L"https://conemu.github.io/en/Wh
 #define gsPortableApps_DefaultXml   L"\\..\\DefaultData\\settings\\ConEmu.xml"
 #define gsPortableApps_ConEmuXmlDir L"\\..\\..\\Data\\settings"
 
-ENCDS lpEnableNonClientDpiScaling = &Stub_EnableNonClientDpiScaling;
-
-BOOL __stdcall Impl_EnableNonClientDpiScaling(HWND hWnd) {
-	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-	return FALSE;
-}
-
-BOOL __stdcall Stub_EnableNonClientDpiScaling(HWND hWnd) {
-	ENCDS func = (ENCDS)GetProcAddress(GetModuleHandle(L"user32.dll"), "EnableNonClientDpiScaling");
-	if (!func)
-	{
-		func = &Impl_EnableNonClientDpiScaling;
-	}
-
-	lpEnableNonClientDpiScaling = func;
-	return func(hWnd);
-}
-
 static struct RegisteredHotKeys
 {
 	int DescrID;
@@ -8203,7 +8185,7 @@ void CConEmuMain::OnHideCaption()
 			AdjustWindowRectEx(&rcBefore, nStyle, FALSE, nStyleEx);
 			if (isZoomed())
 			{
-				int nCapY = GetSystemMetrics(SM_CYCAPTION);
+				int nCapY = CDpiAware::GetDpiAwareMetrics(SM_CYCAPTION, ghWnd);
 				if (gpSet->isCaptionHidden())
 					rcAfter.top -= nCapY;
 				else
@@ -13402,7 +13384,7 @@ LRESULT CConEmuMain::WndProc(HWND hWnd, UINT messg, WPARAM wParam, LPARAM lParam
 			break;
 
 		case WM_NCCREATE:
-			lpEnableNonClientDpiScaling(hWnd);
+			CDpiAware::EnableNonClientDpiScaling(hWnd);
 			return DefWindowProc(hWnd, messg, wParam, lParam);
 
 		case WM_SETHOTKEY:

--- a/src/ConEmu/ConEmu.h
+++ b/src/ConEmu/ConEmu.h
@@ -102,12 +102,6 @@ typedef BOOL (WINAPI* ImmSetCompositionFontW_t)(HIMC hIMC, LPLOGFONT lplf);
 typedef BOOL (WINAPI* ImmSetCompositionWindow_t)(HIMC hIMC, LPCOMPOSITIONFORM lpCompForm);
 typedef HIMC (WINAPI* ImmGetContext_t)(HWND hWnd);
 
-// Optional support for EnableNonClientDpiScaling (when present)
-typedef BOOL(__stdcall *ENCDS)(HWND);
-BOOL __stdcall Impl_EnableNonClientDpiScaling(HWND hWnd);
-BOOL __stdcall Stub_EnableNonClientDpiScaling(HWND hWnd);
-
-
 
 //struct GuiShellExecuteExArg
 //{

--- a/src/ConEmu/ConEmu.h
+++ b/src/ConEmu/ConEmu.h
@@ -102,6 +102,12 @@ typedef BOOL (WINAPI* ImmSetCompositionFontW_t)(HIMC hIMC, LPLOGFONT lplf);
 typedef BOOL (WINAPI* ImmSetCompositionWindow_t)(HIMC hIMC, LPCOMPOSITIONFORM lpCompForm);
 typedef HIMC (WINAPI* ImmGetContext_t)(HWND hWnd);
 
+// Optional support for EnableNonClientDpiScaling (when present)
+typedef BOOL(__stdcall *ENCDS)(HWND);
+BOOL __stdcall Impl_EnableNonClientDpiScaling(HWND hWnd);
+BOOL __stdcall Stub_EnableNonClientDpiScaling(HWND hWnd);
+
+
 
 //struct GuiShellExecuteExArg
 //{

--- a/src/ConEmu/ConEmuSize.cpp
+++ b/src/ConEmu/ConEmuSize.cpp
@@ -212,8 +212,8 @@ RECT CConEmuSize::CalcMargins(DWORD/*enum ConEmuMargins*/ mg, ConEmuWindowMode w
 			_ASSERTE(FALSE);
 			if ((mg & ((DWORD)CEM_FRAMECAPTION)) != CEM_CAPTION)
 			{
-				rc.left = rc.right = GetSystemMetrics(SM_CXSIZEFRAME);
-				rc.bottom = GetSystemMetrics(SM_CYSIZEFRAME);
+				rc.left = rc.right = CDpiAware::GetDpiAwareMetrics(SM_CXSIZEFRAME, ghWnd);
+				rc.bottom = CDpiAware::GetDpiAwareMetrics(SM_CYSIZEFRAME, ghWnd);
 				rc.top = rc.bottom; // рамка
 			}
 
@@ -229,7 +229,7 @@ RECT CConEmuSize::CalcMargins(DWORD/*enum ConEmuMargins*/ mg, ConEmuWindowMode w
 				else
 				#endif
 				{
-					rc.top += GetSystemMetrics(SM_CYCAPTION);
+					rc.top += CDpiAware::GetDpiAwareMetrics(SM_CYCAPTION, ghWnd);
 				}
 			}
 		}
@@ -341,7 +341,7 @@ RECT CConEmuSize::CalcMargins(DWORD/*enum ConEmuMargins*/ mg, ConEmuWindowMode w
 
 	if ((mg & ((DWORD)CEM_SCROLL)) && (gpSet->isAlwaysShowScrollbar == 1))
 	{
-		rc.right += GetSystemMetrics(SM_CXVSCROLL);
+		rc.right += CDpiAware::GetDpiAwareMetrics(SM_CXVSCROLL, ghWnd);
 	}
 
 	if ((mg & ((DWORD)CEM_STATUS)) && gpSet->isStatusBarShow)
@@ -1747,7 +1747,7 @@ void CConEmuSize::CascadedPosFix()
 	if (gpSet->wndCascade && (ghWnd == NULL) && (WindowMode == wmNormal) && IsSizePosFree(WindowMode))
 	{
 		// Сдвиг при каскаде
-		int nShift = (GetSystemMetrics(SM_CYSIZEFRAME)+GetSystemMetrics(SM_CYCAPTION))*1.5;
+		int nShift = (CDpiAware::GetDpiAwareMetrics(SM_CYSIZEFRAME, ghWnd)+CDpiAware::GetDpiAwareMetrics(SM_CYCAPTION, ghWnd))*1.5;
 		// Monitor information
 		MONITORINFO mi;
 		// Preferred window size
@@ -5259,8 +5259,8 @@ HRGN CConEmuSize::CreateWindowRgn(bool abTestOnly/*=false*/)
 			// с FullScreen не совпадает. Нужно с учетом заголовка
 			// сюда мы попадаем только когда заголовок НЕ скрывается
 			RECT rcScreen = CalcRect(CER_FULLSCREEN, MakeRect(0,0), CER_FULLSCREEN);
-			int nCX = GetSystemMetrics(SM_CXSIZEFRAME);
-			int nCY = GetSystemMetrics(SM_CYSIZEFRAME);
+			int nCX = CDpiAware::GetDpiAwareMetrics(SM_CXSIZEFRAME, ghWnd);
+			int nCY = CDpiAware::GetDpiAwareMetrics(SM_CYSIZEFRAME, ghWnd);
 			hRgn = CreateWindowRgn(abTestOnly, false, nCX, nCY, rcScreen.right-rcScreen.left, rcScreen.bottom-rcScreen.top);
 		}
 	}
@@ -5346,7 +5346,7 @@ HRGN CConEmuSize::CreateWindowRgn(bool abTestOnly/*=false*/)
 						}
 						else if (nFrame < 0)
 						{
-							nFrame = GetSystemMetrics(SM_CXSIZEFRAME);
+							nFrame = CDpiAware::GetDpiAwareMetrics(SM_CXSIZEFRAME, ghWnd);
 						}
 						bCreateRgn = true;
 					}

--- a/src/ConEmu/DpiAware.cpp
+++ b/src/ConEmu/DpiAware.cpp
@@ -43,6 +43,61 @@ static bool gbSkipSetDialogDPI = false;
 //#define DPI_DEBUG_CUSTOM 144 // 96, 120, 144, 192 - these are standard dpi-s
 #undef DPI_DEBUG_CUSTOM
 
+// EnableNonClientDpiScaling only exists in Windows 10 build >= 14393
+ENCDS lpEnableNonClientDpiScaling = &Stub_EnableNonClientDpiScaling;
+
+BOOL __stdcall Impl_EnableNonClientDpiScaling(HWND hWnd) {
+	SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+	return FALSE;
+}
+
+BOOL __stdcall Stub_EnableNonClientDpiScaling(HWND hWnd) {
+	ENCDS func = (ENCDS)GetProcAddress(GetModuleHandle(L"user32.dll"), "EnableNonClientDpiScaling");
+	if (!func)
+	{
+		func = &Impl_EnableNonClientDpiScaling;
+	}
+
+	lpEnableNonClientDpiScaling = func;
+	return func(hWnd);
+}
+
+
+GSMFD lpGetSystemMetricsForDpi = &Stub_GetSystemMetricsForDpi;
+
+int __stdcall Impl_GetSystemMetricsForDpi(int nIndex, UINT dpi) {
+	return GetSystemMetrics(nIndex);
+}
+
+int __stdcall Stub_GetSystemMetricsForDpi(int nIndex, UINT dpi) {
+	GSMFD func = (GSMFD)GetProcAddress(GetModuleHandle(L"user32.dll"), "GetSystemMetricsForDpi");
+	if (!func)
+	{
+		func = &Impl_GetSystemMetricsForDpi;
+	}
+
+	lpGetSystemMetricsForDpi = func;
+	return func(nIndex, dpi);
+}
+
+GDFW lpGetDpiForWindow = &Stub_GetDpiForWindow;
+
+UINT __stdcall Impl_GetDpiForWindow(HWND hWnd) {
+	return 0;
+}
+
+UINT __stdcall Stub_GetDpiForWindow(HWND hWnd) {
+	GDFW func = (GDFW)GetProcAddress(GetModuleHandle(L"user32.dll"), "GetDpiForWindow");
+	if (!func)
+	{
+		func = &Impl_GetDpiForWindow;
+	}
+
+	lpGetDpiForWindow = func;
+	return func(hWnd);
+}
+
+
 /*
 struct DpiValue
 	int Ydpi;
@@ -381,6 +436,13 @@ void CDpiAware::CenterDialog(HWND hDialog)
 	}
 }
 
+void CDpiAware::EnableNonClientDpiScaling(HWND hWnd) {
+	lpEnableNonClientDpiScaling(hWnd);
+}
+
+UINT CDpiAware::GetDpiAwareMetrics(int nIndex, HWND hWnd) {
+	return lpGetSystemMetricsForDpi(nIndex, lpGetDpiForWindow(hWnd));
+}
 
 /*
 class CDpiForDialog - handle per-monitor dpi for our resource-based dialogs

--- a/src/ConEmu/DpiAware.h
+++ b/src/ConEmu/DpiAware.h
@@ -31,6 +31,19 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../common/MArray.h"
 #include "../common/MMap.h"
 
+// Optional support for EnableNonClientDpiScaling (when present)
+typedef BOOL(__stdcall *ENCDS)(HWND);
+BOOL __stdcall Impl_EnableNonClientDpiScaling(HWND hWnd);
+BOOL __stdcall Stub_EnableNonClientDpiScaling(HWND hWnd);
+
+typedef int(__stdcall *GSMFD)(int, UINT);
+int __stdcall Impl_GetSystemMetricsForDpi(int nIndex, UINT dpi);
+int __stdcall Stub_GetSystemMetricsForDpi(int nIndex, UINT dpi);
+
+typedef UINT(__stdcall *GDFW)(HWND);
+UINT __stdcall Impl_GetDpiForWindow(HWND hWnd);
+UINT __stdcall Stub_GetDpiForWindow(HWND hWnd);
+
 enum ProcessDpiAwareness
 {
 	Process_DPI_Unaware            = 0,
@@ -95,6 +108,9 @@ public:
 	// Dialog helper
 	static void GetCenteredRect(HWND hWnd, RECT& rcCentered, HMONITOR hDefault = NULL);
 	static void CenterDialog(HWND hDialog);
+
+	static void EnableNonClientDpiScaling(HWND hWnd);
+	static UINT CDpiAware::GetDpiAwareMetrics(int nIndex, HWND hWnd);
 };
 
 class CDynDialog;

--- a/src/ConEmu/FrameHolder.cpp
+++ b/src/ConEmu/FrameHolder.cpp
@@ -860,7 +860,7 @@ void CFrameHolder::CalculateCaptionPosition(const RECT &rcWindow, RECT* rcCaptio
 
 void CFrameHolder::CalculateTabPosition(const RECT &rcWindow, const RECT &rcCaption, RECT* rcTabs)
 {
-	int nBtnWidth = GetSystemMetrics(SM_CXSIZE);
+	int nBtnWidth = CDpiAware::GetDpiAwareMetrics(SM_CXSIZE, ghWnd);
 
 	bool bCaptionHidden = gpSet->isCaptionHidden();
 
@@ -868,7 +868,7 @@ void CFrameHolder::CalculateTabPosition(const RECT &rcWindow, const RECT &rcCapt
 
 	rcTabs->left = rcCaption.left;
 	if (bCaptionHidden || gpSet->isTabsInCaption)
-		rcTabs->left += GetSystemMetrics(SM_CXSMICON) + mn_FrameWidth;
+		rcTabs->left += CDpiAware::GetDpiAwareMetrics(SM_CXSMICON, ghWnd) + mn_FrameWidth;
 
 	if (gpSet->nTabsLocation == 0)
 	{
@@ -1408,7 +1408,7 @@ LRESULT CFrameHolder::OnNcHitTest(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lP
 	{
 		if (point.y < gpConEmu->GetDwmClientRectTopOffset())
 		{
-			int nShift = GetSystemMetrics(SM_CXSMICON);
+			int nShift = CDpiAware::GetDpiAwareMetrics(SM_CXSMICON, ghWnd);
 			int nFrame = 2;
 			//RECT wr; GetWindowRect(hWnd, &wr);
 			int nWidth = wr.right - wr.left;
@@ -1420,7 +1420,7 @@ LRESULT CFrameHolder::OnNcHitTest(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				l_result = HTTOPRIGHT;
 			else if (point.x >= (nWidth-nFrame-nShift) && point.y <= nFrame)
 				l_result = HTTOPRIGHT;
-			else if (point.x > nFrame && point.x <= (nFrame+GetSystemMetrics(SM_CXSMICON)))
+			else if (point.x > nFrame && point.x <= (nFrame+ CDpiAware::GetDpiAwareMetrics(SM_CXSMICON, ghWnd)))
 				l_result = HTSYSMENU;
 			else if (point.x <= nFrame)
 				l_result = HTLEFT;
@@ -1486,21 +1486,23 @@ LRESULT CFrameHolder::OnNcHitTest(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lP
 //	return l_result;
 //}
 
+
+
 void CFrameHolder::RecalculateFrameSizes()
 {
 	_ASSERTE(mb_Initialized==TRUE); // CConEmuMain должен позвать из своего конструктора InitFrameHolder()
 
 	//mn_WinCaptionHeight, mn_FrameWidth, mn_FrameHeight, mn_OurCaptionHeight, mn_TabsHeight;
-	mn_WinCaptionHeight = GetSystemMetrics(SM_CYCAPTION);
-	mn_FrameWidth = GetSystemMetrics(SM_CXFRAME);
-	mn_FrameHeight = GetSystemMetrics(SM_CYFRAME);
+	mn_WinCaptionHeight = CDpiAware::GetDpiAwareMetrics(SM_CYCAPTION, ghWnd);
+	mn_FrameWidth = CDpiAware::GetDpiAwareMetrics(SM_CXFRAME, ghWnd);
+	mn_FrameHeight = CDpiAware::GetDpiAwareMetrics(SM_CYFRAME, ghWnd);
 
 	//int nHeightIdeal = mn_WinCaptionHeight * 3 / 4;
 	//if (nHeightIdeal < 19) nHeightIdeal = 19;
 	mn_TabsHeight = GetTabsHeight(); // min(nHeightIdeal,mn_OurCaptionHeight);
 
 	//int nCaptionDragHeight = 10;
-	int nCaptionDragHeight = GetSystemMetrics(SM_CYSIZE); // - mn_FrameHeight;
+	int nCaptionDragHeight = CDpiAware::GetDpiAwareMetrics(SM_CYSIZE, ghWnd); // - mn_FrameHeight;
 	if (gpConEmu->DrawType() >= fdt_Themed)
 	{
 	//	//SIZE sz = {}; RECT tmpRc = MakeRect(600,400);


### PR DESCRIPTION
This PR is not ready to merge yet, but I'm opening it now so we can do proper review.

This attempts to better handle `WM_DPICHANGED`, which is sent when a window is dragged between monitors of different DPIs (eg from a 200dpi 4K display to a regular 96dpi display).  The expected behavior for a per-monitor DPI aware app is to resize the pixel size of the window such that it maintains its physical dimensions and then render the contents of the window at the new DPI.

ConEmu currently does that latter (for the most part).  When a ConEmu window is dragged between different DPI displays, the text in the console, status bar, and tab bar all render at the correct DPI.

However, the window is not resized.  This is easily fixed by calling `SetWindowPos` with the `WM_DPICHANGED`'s `lParam`.  Windows gives you a `RECT` that calculates what pixel size your window must be in order to maintain physical dimensions based on the DPI of the previous monitor and the DPI of the new monitor.

Also added a call to `EnableNonClientDpiScaling`.  This tells Windows that it should also scale the non-client area of the window (ie the titlebar and window borders).  This ensures that the window looks correct on all displays.

Unfortunately--and the reason the PR is not merge-ready--I cannot figure out how to get ConEmu to render correctly after the non-client area is scaled:

![image](https://cloud.githubusercontent.com/assets/354349/21921704/f6c3872e-d91e-11e6-927b-6ebf11e9a9c0.png)

Notice that when the window is dragged to a low-DPI display, the tab bar continues to position itself the same number of pixels from the top of the window as on a high-DPI display.  The margins around the status bar and console itself are also incorrect.

I suspect that this might be because `GetSystemMetrics` returns the metrics for the system DPI (in this case, the high-DPI display), which is why I added `GetDpiAwareMetrics`, which returns metrics based on the display that the window `hWnd` is currently on.  Unfortunately, I must be missing something since this does not fix the problem (even though the metrics appear to be correct now).

**tl;dr:** Any ideas on how to get the margins to calculate correctly after the non-client sizes change would be greatly appreciated.

Fixes #275.