### PR TITLE
Patch ansicolors24bit.ps1 for wsl

### DIFF
--- a/Release/ConEmu/Addons/AnsiColors24bit.ps1
+++ b/Release/ConEmu/Addons/AnsiColors24bit.ps1
@@ -36,7 +36,7 @@ while ($l -lt $h) {
     Write-Host -NoNewLine (([char]27)+"[48;2;"+$r+";255;"+$b+"m ")
     $c++
   }
-  Write-Host -NoNewLine (([char]27)+"[m ")
+  Write-Host (([char]27)+"[m ")
   $l++
 }
 

--- a/Release/ConEmu/Addons/AnsiColors24bit.ps1
+++ b/Release/ConEmu/Addons/AnsiColors24bit.ps1
@@ -11,8 +11,12 @@ Write-Host (([char]27)+"[9999S")
 cls
 
 # Ensure that we are in the bottom of the buffer
-[Console]::SetWindowPosition(0,$y)
-[Console]::SetCursorPosition(0,$y)
+try{
+  [Console]::SetWindowPosition(0,$y)
+  [Console]::SetCursorPosition(0,$y)
+}catch{
+  Write-Host (([char]27)+"[9999;1H")
+}
 
 # Header
 $title = " Printing 24bit gradient with ANSI sequences using powershell"


### PR DESCRIPTION
Powershell is available for linux (see https://github.com/PowerShell/PowerShell) and also runs in Bash on Windows (WSL).
Sadly https://github.com/Maximus5/ConEmu/blob/daily/Release/ConEmu/Addons/AnsiColors24bit.ps1 doesn't work.
`[Console]::SetWindowPosition(0,$y)` and `[Console]::SetCursorPosition(0,$y)` do not work in WSL,
so this patch uses an escape sequence instead.

One more change is needed to  get multiple output lines:
`-NoNewLine` was removed at one place.

With these change AnsiColors24bit.ps1 works within WSL (when using `wslbridge` and `cygwin-connector`) and in native powershell on windows.