### PR TITLE
Fix Far1 "edit console output" empty output

### DIFF
--- a/src/ConEmu/ConEmu.cpp
+++ b/src/ConEmu/ConEmu.cpp
@@ -1139,7 +1139,7 @@ bool CConEmuMain::CheckRequiredFiles()
 			_wcscat_c(pszMsg, cchMax, L"\n");
 			if (*szRequired)
 			{
-				_wcscat_c(pszMsg, cchMax, L"\nConEmu will exits now");
+				_wcscat_c(pszMsg, cchMax, L"\nConEmu will exit now");
 			}
 			MsgBox(pszMsg, MB_SYSTEMMODAL|(*szRequired ? MB_ICONSTOP : MB_ICONWARNING), GetDefaultTitle(), NULL);
 			free(pszMsg);

--- a/src/ConEmuHk/ShellProcessor.cpp
+++ b/src/ConEmuHk/ShellProcessor.cpp
@@ -2266,7 +2266,7 @@ int CShellProc::PrepareExecuteParms(
 	else
 	{
 		// хотят GUI прицепить к новой вкладке в ConEmu, или новую консоль из GUI
-		if (lbGuiApp && (NewConsoleFlags || bForceNewConsole))
+		if ((bLongConsoleOutput) || (lbGuiApp && (NewConsoleFlags || bForceNewConsole)))
 			bGoChangeParm = true;
 		// eCreateProcess перехватывать не нужно (сами сделаем InjectHooks после CreateProcess)
 		else if ((mn_ImageBits != 16) && (m_SrvMapping.bUseInjects & 1)


### PR DESCRIPTION
### Problem description:

"Edit console output" shows empty output.

### Steps to reproduce:

Run ConEmu with Far1,
Run any console program,
Pick "Plugin commands" -> "ConEmu" --> "Edit console output" command

### Actual results
Far1 shows empty editor

### Expected results

Far1 editor window with console output.
