### PR TITLE
When GetConsoleKeyboardLayoutName not implemented stop calling it

### DIFF
--- a/src/ConEmuCD/ConsoleMain.cpp
+++ b/src/ConEmuCD/ConsoleMain.cpp
@@ -7021,7 +7021,8 @@ bool IsKeyboardLayoutChanged(DWORD* pdwLayout)
 		return false;
 	}
 
-	if (pfnGetConsoleKeyboardLayoutName)
+	static bool bGetConsoleKeyboardLayoutNameImplemented = true;
+	if (bGetConsoleKeyboardLayoutNameImplemented && pfnGetConsoleKeyboardLayoutName)
 	{
 		wchar_t szCurKeybLayout[32] = L"";
 
@@ -7053,6 +7054,14 @@ bool IsKeyboardLayoutChanged(DWORD* pdwLayout)
 
 		if (!bConApiRc)
 		{
+			// If GetConsoleKeyboardLayoutName is not implemented in Windows, ERROR_MR_MID_NOT_FOUND will be returned
+			// because there is no matching DOS/Win32 error code for NTSTATUS code returned. When this happens, we don't
+			// want to continue to call the function.
+			if (ERROR_MR_MID_NOT_FOUND == nErr)
+			{
+				bGetConsoleKeyboardLayoutNameImplemented = false;
+			}
+
 			if (gpSrv->szKeybLayout[0])
 			{
 				// Log only first error per session


### PR DESCRIPTION
This eliminates recurring calls to GetConsoleKeyboardLayoutName when we get an error code that indicates that it is not implemented. These calls result in a bunch of debug out messages that appear in kernel debuggers (or DbgView when capturing the same events).

I've tested it on Windows 10 RS2 and verified that prior to my fix, the debug out matches that described in #1236. After my fix, the debug out messages about a deprecated and not implemented API call are no longer there.

Note that this does NOT fix the other debug message in the issue, about a bad handle from a call to GetConsoleDisplayMode. I concur with the issue comments that this one is a Microsoft issue that can't be fixed short of not calling that API at all.