### PR TITLE
Fix "Far Manager -> Panel Views -> Max. Zoom combo box" assertion

### DIFF
--- a/src/ConEmu/SetPgViews.cpp
+++ b/src/ConEmu/SetPgViews.cpp
@@ -181,6 +181,7 @@ INT_PTR CSetPgViews::OnComboBox(HWND hDlg, WORD nCtrlId, WORD code)
 					break;
 				case tThumbMaxZoom:
 					gpSet->ThSet.nMaxZoom = max(100,((nSel+1)*100));
+					break;
 				default:
 					_ASSERTE(FALSE && "ListBox was not processed");
 			}

--- a/src/ConEmuPlugin/ConEmuPluginA.cpp
+++ b/src/ConEmuPlugin/ConEmuPluginA.cpp
@@ -225,7 +225,7 @@ bool CPluginAnsi::GetPanelItemInfo(const CEPanelInfo& PnlInfo, bool bSelected, I
 	Info.nFileSizeLow = pItem->FindData.nFileSizeLow;
 
 	MultiByteToWideChar(CP_OEMCP, 0, pItem->FindData.cFileName, -1, Info.cFileName, countof(Info.cFileName));
-	MultiByteToWideChar(CP_OEMCP, 0, pItem->FindData.cAlternateFileName, -1, Info.cAlternateFileName, countof(Info.cFileName));
+	MultiByteToWideChar(CP_OEMCP, 0, pItem->FindData.cAlternateFileName, -1, Info.cAlternateFileName, countof(Info.cAlternateFileName));
 
 	if (ppszFullPathName)
 		*ppszFullPathName = lstrdup(Info.cFileName);

--- a/src/common/RgnDetect.cpp
+++ b/src/common/RgnDetect.cpp
@@ -831,6 +831,7 @@ bool CRgnDetect::FindDialog_Inner(wchar_t* pChar, CharAttr* pAttr, int nWidth, i
 			case ucBoxSinglUpDblHorz:
 			case ucBoxDblUpDblHorz:
 				nY++; // пометить все сверху (включая)
+				break;
 				// иначе - прервать поиск и пометить все сверху (не включая)
 			default:
 				nY--;


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects.
I found an issue within one of the ConEmu settings' pages where you simply can get an assertion by touching one of comboboxes. To reproduce the bug follow these steps:

- Goto ConEmu Settings dialog window;
- Goto `Far Manager -> Panel Views` page;
- Try to change `Max. zoom:` combobox.
- Boom! You've got an assertion `ListBox was not processed`

Reason is simple — one missing `break` in `switch` statement that leads you to the `default:` branch after performing `case tThumbMaxZoom:` code. Luckily, this mistake was easily found by PVS-Studio analyzer:

- [V796](https://www.viva64.com/en/w/v796/) It is possible that 'break' statement is missing in switch statement. setpgviews.cpp 183

Mainly this PR is intended to fix that behaviour. But PVS-Studio found a couple of more additional errors which are not so serious to cause any misbehaviour during your interraction with the program but they are still dangerous in some way:

- [V778](https://www.viva64.com/en/w/v778/) Two similar code fragments were found. Perhaps, this is a typo and 'cAlternateFileName' variable should be used instead of 'cFileName'. conemuplugina.cpp 228
- [V796](https://www.viva64.com/en/w/v796/) It is possible that 'break' statement is missing in switch statement. rgndetect.cpp 833

Second commit fixes them as well.
Good luck!