### PR TITLE
[WSL] Use user's default login shell

### DIFF
--- a/Release/ConEmu/wsl/wsl-boot.sh
+++ b/Release/ConEmu/wsl/wsl-boot.sh
@@ -2,4 +2,4 @@
 uname -a
 ./256colors2.pl
 cd ~
-bash -l -i
+`getent passwd $USER | cut -d: -f7` -l -i


### PR DESCRIPTION
win-boot.sh now detects user's default login shell instead of unconditionally launching bash