### PR TITLE
Improve Size & Pos UI; use max buffer height by default

### DIFF
--- a/src/ConEmu/SetPgSizePos.cpp
+++ b/src/ConEmu/SetPgSizePos.cpp
@@ -89,7 +89,7 @@ LRESULT CSetPgSizePos::OnInitDialog(HWND hDlg, bool abInitial)
 
 	checkDlgButton(hDlg, cbLongOutput, gpSet->AutoBufferHeight);
 	TODO("Надо бы увеличить, но нужно сервер допиливать");
-	SendDlgItemMessage(hDlg, tLongOutputHeight, EM_SETLIMITTEXT, 5, 0);
+	SendDlgItemMessage(hDlg, tLongOutputHeight, EM_SETLIMITTEXT, 6, 0);
 	SetDlgItemInt(hDlg, tLongOutputHeight, gpSet->DefaultBufferHeight, FALSE);
 	//EnableWindow(GetDlgItem(hDlg, tLongOutputHeight), gpSet->AutoBufferHeight);
 

--- a/src/ConEmu/SetPgSizePos.cpp
+++ b/src/ConEmu/SetPgSizePos.cpp
@@ -232,7 +232,7 @@ LRESULT CSetPgSizePos::OnEditChanged(HWND hDlg, WORD nCtrlId)
 			if (nNewVal >= LONGOUTPUTHEIGHT_MIN && nNewVal <= LONGOUTPUTHEIGHT_MAX)
 				gpSet->DefaultBufferHeight = nNewVal;
 			else if (nNewVal > LONGOUTPUTHEIGHT_MAX)
-				SetDlgItemInt(hDlg, nCtrlId, gpSet->DefaultBufferHeight, FALSE);
+				SetDlgItemInt(hDlg, nCtrlId, LONGOUTPUTHEIGHT_MAX, FALSE);
 		}
 		else
 		{

--- a/src/ConEmuCD/ConsoleMain.cpp
+++ b/src/ConEmuCD/ConsoleMain.cpp
@@ -5060,7 +5060,7 @@ void SendStarted()
 				if (gpSrv->DbgInfo.bDebuggerActive && !gnBufferHeight)
 				{
 					_ASSERTE(gnRunMode != RM_ALTSERVER);
-					gnBufferHeight = 9999;
+					gnBufferHeight = LONGOUTPUTHEIGHT_MAX;
 				}
 
 				SMALL_RECT rcNil = {0};

--- a/src/ConEmuPlugin/ConEmuPluginBase.cpp
+++ b/src/ConEmuPlugin/ConEmuPluginBase.cpp
@@ -1526,16 +1526,16 @@ bool CPluginBase::StartDebugger()
 		// Откроем дебаггер в новой вкладке ConEmu. При желании юзеру проще сделать Detach
 		// "/DEBUGPID=" обязательно должен быть первым аргументом
 
-		swprintf_c(szExe, L"\"%s\" /ATTACH /ROOT \"%s\" /DEBUGPID=%i /BW=%i /BH=%i /BZ=9999",
-		          szConEmuC, szConEmuC, dwSelfPID, w, h);
-		//swprintf_c(szExe, L"\"%s\" /ATTACH /GID=%u /GHWND=%08X /ROOT \"%s\" /DEBUGPID=%i /BW=%i /BH=%i /BZ=9999",
-		//          szConEmuC, nGuiPID, (DWORD)(DWORD_PTR)ghConEmuWndDC, szConEmuC, dwSelfPID, w, h);
+		swprintf_c(szExe, L"\"%s\" /ATTACH /ROOT \"%s\" /DEBUGPID=%i /BW=%i /BH=%i /BZ=%i",
+		          szConEmuC, szConEmuC, dwSelfPID, w, h, LONGOUTPUTHEIGHT_MAX);
+		//swprintf_c(szExe, L"\"%s\" /ATTACH /GID=%u /GHWND=%08X /ROOT \"%s\" /DEBUGPID=%i /BW=%i /BH=%i /BZ=%i",
+		//          szConEmuC, nGuiPID, (DWORD)(DWORD_PTR)ghConEmuWndDC, szConEmuC, dwSelfPID, w, h, LONGOUTPUTHEIGHT_MAX);
 	}
 	else
 	{
 		// Запустить дебаггер в новом видимом консольном окне
-		swprintf_c(szExe, L"\"%s\" /DEBUGPID=%i /BW=%i /BH=%i /BZ=9999",
-		          szConEmuC, dwSelfPID, w, h);
+		swprintf_c(szExe, L"\"%s\" /DEBUGPID=%i /BW=%i /BH=%i /BZ=%i",
+		          szConEmuC, dwSelfPID, w, h, LONGOUTPUTHEIGHT_MAX);
 	}
 
 	if (ghConEmuWndDC)


### PR DESCRIPTION
- When users enter 99999 for console buffer height, 32766 is substituted.

- When users enter 222222 or 111111 for console buffer height, 32766 is used instead.

- New buffers spawn with 32766 as console buffer height