### PR TITLE
Add a new option to auto-trim single lines.

### DIFF
--- a/src/ConEmu/ConEmu.rc
+++ b/src/ConEmu/ConEmu.rc
@@ -911,7 +911,7 @@ BEGIN
     CONTROL         "First line",rPasteM2FirstLine,"Button",BS_AUTORADIOBUTTON,206,41,78,8
     CONTROL         "Single line",rPasteM2SingleLine,"Button",BS_AUTORADIOBUTTON,288,26,78,8
     CONTROL         "Do nothing",rPasteM2Nothing,"Button",BS_AUTORADIOBUTTON,288,41,78,8
-    GROUPBOX        "Confirm critical actions",gbPasteConfirm,10,80,364,64,WS_GROUP
+    GROUPBOX        "Confirm critical actions",gbPasteConfirm,10,80,364,79,WS_GROUP
     CONTROL         "Multi-line paste: avoid unexpected command execution by <Enter> keypress",cbClipConfirmEnter,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,93,355,8
     CONTROL         "Long text paste: avoid non-responsive console until the paste finishes",cbClipConfirmLimit,
@@ -922,6 +922,8 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,56,163,10
     CONTROL         "Allow Windows to POSIX path conversion",cbPasteM2Posix,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,206,56,163,10
+    CONTROL         "Automatically remove newline when pasting single line",cbAutoTrimSingleLine,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,141,253,10
 END
 
 IDD_SPG_ENVIRONMENT DIALOGEX 0, 0, 381, 242
@@ -1665,6 +1667,10 @@ END
 #ifdef APSTUDIO_INVOKED
 GUIDELINES DESIGNINFO
 BEGIN
+    IDD_CMDPROMPT, DIALOG
+    BEGIN
+    END
+
     IDD_SPG_PASTE, DIALOG
     BEGIN
     END

--- a/src/ConEmu/Options.cpp
+++ b/src/ConEmu/Options.cpp
@@ -2748,6 +2748,7 @@ void Settings::LoadSettings(bool& rbNeedCreateVanilla, const SettingsStorage* ap
 		reg->Load(L"CTS.ColorIndex", isCTSColorIndex); if (CONFORECOLOR(isCTSColorIndex) == CONBACKCOLOR(isCTSColorIndex)) isCTSColorIndex = DefaultSelectionConsoleColor;
 
 		reg->Load(L"ClipboardConfirmEnter", isPasteConfirmEnter);
+		reg->Load(L"AutoTrimSingleLine", isAutoTrimSingleLine);
 		reg->Load(L"ClipboardConfirmLonger", nPasteConfirmLonger);
 
 		reg->Load(L"FarGotoEditorOpt", isFarGotoEditor);
@@ -3803,6 +3804,7 @@ BOOL Settings::SaveSettings(BOOL abSilent /*= FALSE*/, const SettingsStorage* ap
 		reg->Save(L"CTS.ColorIndex", isCTSColorIndex);
 
 		reg->Save(L"ClipboardConfirmEnter", isPasteConfirmEnter);
+		reg->Save(L"AutoTrimSingleLine", isAutoTrimSingleLine);
 		reg->Save(L"ClipboardConfirmLonger", nPasteConfirmLonger);
 
 		reg->Save(L"FarGotoEditorOpt", isFarGotoEditor);

--- a/src/ConEmu/Options.h
+++ b/src/ConEmu/Options.h
@@ -580,6 +580,8 @@ struct Settings
 		BYTE isCTSColorIndex;
 		//reg->Load(L"ClipboardConfirmEnter", isPasteConfirmEnter);
 		bool isPasteConfirmEnter;
+		//reg->Load(L"AutoTrimSingleLine", isAutoTrimSingleLine);
+		bool isAutoTrimSingleLine;
 		//reg->Load(L"ClipboardConfirmLonger", nPasteConfirmLonger);
 		UINT nPasteConfirmLonger;
 		//reg->Load(L"FarGotoEditorOpt", isFarGotoEditor);

--- a/src/ConEmu/RealConsole.cpp
+++ b/src/ConEmu/RealConsole.cpp
@@ -12477,6 +12477,19 @@ void CRealConsole::Paste(CEPasteMode PasteMode /*= pm_Standard*/, LPCWSTR asText
 
 	// Смотрим первую строку / наличие второй
 	wchar_t* pszRN = wcspbrk(pszBuf, L"\r\n");
+
+	// If user has enabled AutoTrimSingleLine, check if we are pasting a single line string.
+	// If so, set PasteMode to pm_OneLine to remove trailing newlines.
+	if (pszRN && gpSet->isAutoTrimSingleLine) {
+		wchar_t* pszNext = pszRN;
+		while ((*pszNext == L'\r') || (*pszNext == L'\n')) {
+			pszNext++;
+		}
+		if (!wcspbrk(pszNext, L"\r\n")) {
+			PasteMode = pm_OneLine;
+		}
+	}
+
 	if (PasteMode == pm_OneLine)
 	{
 		LPCWSTR pszEnd = pszBuf + nBufLen;

--- a/src/ConEmu/SetDlgButtons.cpp
+++ b/src/ConEmu/SetDlgButtons.cpp
@@ -726,6 +726,9 @@ bool CSetDlgButtons::ProcessButtonClick(HWND hDlg, WORD CB, BYTE uCheck)
 		case cbClipConfirmEnter:
 			CSetPgPaste::OnBtn_ClipConfirmEnter(hDlg, CB, uCheck);
 			break;
+		case cbAutoTrimSingleLine:
+			CSetPgPaste::OnBtn_AutoTrimSingleLine(hDlg, CB, uCheck);
+			break;
 		case cbClipConfirmLimit:
 			CSetPgPaste::OnBtn_ClipConfirmLimit(hDlg, CB, uCheck);
 			break;

--- a/src/ConEmu/SetPgPaste.cpp
+++ b/src/ConEmu/SetPgPaste.cpp
@@ -63,6 +63,7 @@ LRESULT CSetPgPaste::OnInitDialog(HWND hDlg, bool abInitial)
 	checkDlgButton(hDlg, cbPasteM2Posix, (gpSet->AppStd.isPosixFirstLine != pxm_Intact) ? BST_CHECKED : BST_UNCHECKED);
 
 	checkDlgButton(hDlg, cbClipConfirmEnter, gpSet->isPasteConfirmEnter);
+	checkDlgButton(hDlg, cbAutoTrimSingleLine, gpSet->isAutoTrimSingleLine);
 
 	checkDlgButton(hDlg, cbClipConfirmLimit, (gpSet->nPasteConfirmLonger!=0));
 	SetDlgItemInt(hDlg, tClipConfirmLimit, gpSet->nPasteConfirmLonger, FALSE);
@@ -152,6 +153,17 @@ void CSetPgPaste::OnBtn_ClipConfirmEnter(HWND hDlg, WORD CB, BYTE uCheck)
 	gpSet->isPasteConfirmEnter = (uCheck != BST_UNCHECKED);
 
 } // cbClipConfirmEnter
+
+
+// cbAutoTrimSingleLine
+void CSetPgPaste::OnBtn_AutoTrimSingleLine(HWND hDlg, WORD CB, BYTE uCheck)
+{
+	_ASSERTE(CB == cbAutoTrimSingleLine);
+
+	gpSet->isAutoTrimSingleLine = (uCheck != BST_UNCHECKED);
+
+} // cbAutoTrimSingleLine
+
 
 // cbClipConfirmLimit
 void CSetPgPaste::OnBtn_ClipConfirmLimit(HWND hDlg, WORD CB, BYTE uCheck)

--- a/src/ConEmu/SetPgPaste.h
+++ b/src/ConEmu/SetPgPaste.h
@@ -54,6 +54,7 @@ public:
 	static void OnBtn_ClipCtrlV(HWND hDlg, WORD CB, BYTE uCheck);
 	static void OnBtn_ClipPosixCvt(HWND hDlg, WORD CB, BYTE uCheck);
 	static void OnBtn_ClipConfirmEnter(HWND hDlg, WORD CB, BYTE uCheck);
+	static void OnBtn_AutoTrimSingleLine(HWND hDlg, WORD CB, BYTE uCheck);
 	static void OnBtn_ClipConfirmLimit(HWND hDlg, WORD CB, BYTE uCheck);
 
 protected:

--- a/src/ConEmu/resource.h
+++ b/src/ConEmu/resource.h
@@ -1338,6 +1338,7 @@
 #define cbRestoreInactive               3099
 #define cbInactiveCursorSubstHidden     3100
 #define vkCheckUpdates                  3101
+#define cbAutoTrimSingleLine            3102
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -1346,7 +1347,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        246
 #define _APS_NEXT_COMMAND_VALUE         40010
-#define _APS_NEXT_CONTROL_VALUE         3102
+#define _APS_NEXT_CONTROL_VALUE         3103
 #define _APS_NEXT_SYMED_VALUE           130
 #endif
 #endif


### PR DESCRIPTION
When pasting a single line ending in newline, the user is presented with a
warning about pasting multi-line strings. This enables a new option to
automatically strip trailing newlines whenever we detect that a single line
string has been pasted. This prevents the warning and allows the user to more
conveniently edit single lines pasted into the console.




![2018-08-09 22_31_35-settings xml conemu 180626 64 preview](https://user-images.githubusercontent.com/10999400/43935914-2739c1ba-9c24-11e8-8302-c0f001c62316.png)
