### PR TITLE
Add support for generating VS2019 tasks

### DIFF
--- a/src/ConEmu/OptionsFast.cpp
+++ b/src/ConEmu/OptionsFast.cpp
@@ -2145,6 +2145,7 @@ static void CreateVCTask(AppFoundList& App, LPCWSTR pszPlatform, LPCWSTR pszVer,
 		LPCWSTR pszIconSfx;
 		switch (iVer)
 		{
+		case 16: pszIconSfx = L",43\""; break;
 		case 15: pszIconSfx = L",38\""; break;
 		case 14: pszIconSfx = L",33\""; break;
 		case 12: pszIconSfx = L",28\""; break;


### PR DESCRIPTION
The ID number of VS2019/VC16's icon is 43. Nothing else changed from VS2017.