### PR TITLE
Tab icon quality fix (#1072)

### DIFF
--- a/src/ConEmu/IconList.cpp
+++ b/src/ConEmu/IconList.cpp
@@ -116,7 +116,7 @@ bool CIconList::Initialize()
 		swprintf_c(szLog, L"Creating IconList for size {%ix%i} SysIcon size is {%ix%i}", mn_CxIcon, mn_CyIcon, iSysX, iSysY);
 		gpConEmu->LogString(szLog);
 
-		if ((mh_TabIcons = ImageList_Create(mn_CxIcon, mn_CyIcon, ILC_COLOR24|ILC_MASK, 0, 16)) != NULL)
+		if ((mh_TabIcons = ImageList_Create(mn_CxIcon, mn_CyIcon, ILC_COLOR32|ILC_MASK, 0, 16)) != NULL)
 		{
 			CToolImg img;
 			int nFirstAdd = -1;

--- a/src/ConEmu/IconList.h
+++ b/src/ConEmu/IconList.h
@@ -48,6 +48,7 @@ protected:
 public:
 	HIMAGELIST mh_TabIcons = nullptr;
 	int mn_AdminIcon = -1;
+	int mn_AdminOverlayIndex = -1;
 public:
 	CIconList();
 	~CIconList();


### PR DESCRIPTION
This PR closes #1072.

First of all, I had to change the `mh_TabIcons` to use 32-bit color (with alpha channel), and it worked.

But after that, I had troubles with the admin overlay icon as I've already stated in [the issue comments](https://github.com/Maximus5/ConEmu/issues/1072#issuecomment-351106729):

> […]
>
> But then I saw the admin icons after my patch:
>
> Before:  ![image](https://user-images.githubusercontent.com/92793/33895301-cdecdad2-df92-11e7-8551-5f97149d1934.png)
> 
> After: ![image](https://user-images.githubusercontent.com/92793/33895327-d9d19de2-df92-11e7-8cba-4fc9d7ee3a79.png)
> 
> (Yes, that's literally a fully-transparent hole instead of a shield icon).

So, it looks like the inner workings of the image lists are very bizarre and I wasn't able to fully understand them, but they just use a wrong (and also inverted!) mask when drawing the icon after copying the icon from the temporary image list.

There's no straight way around it, but I've found a good workaround: instead of creating a temporary image list and combining the icons with `ImageList_Merge`, we'll set up our tiny shield icon as a list overlay icon (`ImageList_SetOverlayImage`).

It also allows us to simplify the image drawing code a bit (because we don't need the temporary image list anymore). The result looks like that:

![image](https://user-images.githubusercontent.com/92793/63745860-7814f100-c8cd-11e9-83d7-20aa313a0abe.png)

(yes, the admin overlay is still a bit ugly, but that's just because it has lower resolution than most of the other icons; it should be easy to fix and that's a separate issue anyway)