### PR TITLE
Redraw toolbar correctly when monitor DPI changes

### DIFF
--- a/src/ConEmu/ConEmuSize.cpp
+++ b/src/ConEmu/ConEmuSize.cpp
@@ -5347,8 +5347,6 @@ LRESULT CConEmuSize::OnDpiChanged(UINT dpiX, UINT dpiY, LPRECT prcSuggested, boo
 		#endif
 
 		SizeInfo::RequestDpi(DpiValue(dpiX, dpiY));
-		if (prcSuggested)
-			SizeInfo::RequestRect(*prcSuggested);
 
 		// it returns false if DPI was not changed
 		if (gpFontMgr->RecreateFontByDpi(dpiX, dpiY, prcSuggested))
@@ -5389,6 +5387,9 @@ LRESULT CConEmuSize::OnDpiChanged(UINT dpiX, UINT dpiY, LPRECT prcSuggested, boo
 				}
 			}
 		}
+
+		if (prcSuggested)
+			SizeInfo::RequestRect(*prcSuggested);
 	}
 
 	return lRc;

--- a/src/ConEmu/FontMgr.cpp
+++ b/src/ConEmu/FontMgr.cpp
@@ -1323,7 +1323,7 @@ bool CFontMgr::RecreateFontByDpi(int dpiX, int dpiY, LPRECT prcSuggested)
 	_dpi_font.SetDpi(dpiX, dpiY);
 	//Raster fonts???
 	EvalLogfontSizes(LogFont, gpSet->FontSizeY, gpSet->FontSizeX);
-	RecreateFont(true);
+	RecreateFont(true, true);
 
 	return true;
 }

--- a/src/ConEmu/FontMgr.cpp
+++ b/src/ConEmu/FontMgr.cpp
@@ -2440,9 +2440,6 @@ void CFontMgr::RecreateFont(bool abReset, bool abRecreateControls /*= false*/)
 		SaveFontSizes((mn_AutoFontWidth == -1), true);
 
 		{
-			if (abRecreateControls)
-				gpConEmu->RecreateControls(true, true, false);
-
 			gpConEmu->Update(true);
 
 			if (gpConEmu->GetWindowMode() == wmNormal)
@@ -2451,6 +2448,9 @@ void CFontMgr::RecreateFont(bool abReset, bool abRecreateControls /*= false*/)
 				CVConGroup::SyncConsoleToWindow();
 
 			gpConEmu->ReSize();
+
+			if (abRecreateControls)
+				gpConEmu->RecreateControls(true, true, false);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a minor DPI-related bug.

## Bug reproduction
### approach 1

- Open ConEmu and make sure it's not minimized
- Change current monintor's DPI several times
- Toolbar icons become too large or too small

### approach 2

- Have 2 users in your computer
- Change current monintor's DPI to any value other than 96 (100%), for both users
- Login with one user, open ConEmu and make sure it's not minimized
- Use 'switch user' to switch to another user
- Use 'switch user' to switch back
- Toolbar icons become too large or too small
