### PR TITLE
Avoid ill-formed swap

### DIFF
--- a/src/ConEmu/CmdHistory.cpp
+++ b/src/ConEmu/CmdHistory.cpp
@@ -54,7 +54,7 @@ void CommandHistory::FreeItems()
 	{
 		SafeFree(p);
 	}
-	Items.swap(MArray<wchar_t*>());
+	Items.clear();
 }
 
 // Return size in bytes

--- a/src/ConEmu/CmdHistory.cpp
+++ b/src/ConEmu/CmdHistory.cpp
@@ -54,7 +54,7 @@ void CommandHistory::FreeItems()
 	{
 		SafeFree(p);
 	}
-	Items.clear();
+	MArray<wchar_t*>().swap(Items);
 }
 
 // Return size in bytes

--- a/src/common/MToolHelp.h
+++ b/src/common/MToolHelp.h
@@ -157,7 +157,7 @@ public:
 		mb_Started = false;
 		mn_Position = 0;
 
-		m_Items.clear();
+		MArray<T>().swap(m_Items);
 	};
 
 	bool Open()

--- a/src/common/MToolHelp.h
+++ b/src/common/MToolHelp.h
@@ -157,7 +157,7 @@ public:
 		mb_Started = false;
 		mn_Position = 0;
 
-		m_Items.swap(MArray<T>());
+		m_Items.clear();
 	};
 
 	bool Open()


### PR DESCRIPTION
Swapping with a temporary is ill-formed. This fixes a compilation error with G++.
Probably better explicit `shrink_to_fit` if really needed.
