### PR TITLE
Fix cross initializations

### DIFF
--- a/src/ConEmu/ConEmuSize.cpp
+++ b/src/ConEmu/ConEmuSize.cpp
@@ -4596,6 +4596,8 @@ bool CConEmuSize::SetWindowMode(ConEmuWindowMode inMode, bool abForce /*= false*
 
 	DEBUGTEST(BOOL bIsVisible = IsWindowVisible(ghWnd););
 
+	LPCWSTR pszInfo;	
+
 	//!!!
 	switch (NewMode)
 	{
@@ -4908,7 +4910,7 @@ bool CConEmuSize::SetWindowMode(ConEmuWindowMode inMode, bool abForce /*= false*
 		_ASSERTE(FALSE && "Unsupported mode");
 	}
 
-	LPCWSTR pszInfo = L"SetWindowMode done";
+	pszInfo = L"SetWindowMode done";
 	if (!LogString(pszInfo)) { DEBUGSTRWMODE(pszInfo); }
 
 	//WindowMode = inMode; // Запомним!

--- a/src/ConEmu/ConEmuSize.cpp
+++ b/src/ConEmu/ConEmuSize.cpp
@@ -4596,7 +4596,7 @@ bool CConEmuSize::SetWindowMode(ConEmuWindowMode inMode, bool abForce /*= false*
 
 	DEBUGTEST(BOOL bIsVisible = IsWindowVisible(ghWnd););
 
-	LPCWSTR pszInfo;	
+	LPCWSTR pszInfo = NULL;
 
 	//!!!
 	switch (NewMode)

--- a/src/ConEmu/OptionsClass.cpp
+++ b/src/ConEmu/OptionsClass.cpp
@@ -1745,7 +1745,8 @@ LRESULT CSettings::OnPage(LPNMHDR phdr)
 void CSettings::Dialog(int IdShowPage /*= 0*/)
 {
 	const TabHwndIndex lastPageId = gpSetCls->m_LastActivePageId;
-
+	TabHwndIndex showPage;
+	
 	if (!ghOpWnd || !IsWindow(ghOpWnd))
 	{
 		_ASSERTE(isMainThread());
@@ -1780,7 +1781,7 @@ void CSettings::Dialog(int IdShowPage /*= 0*/)
 
 	apiShowWindow(ghOpWnd, SW_SHOWNORMAL);
 
-	TabHwndIndex showPage = thi_Last;
+	showPage = thi_Last;
 	if (IdShowPage)
 		showPage = gpSetCls->GetPageIdByDialogId(IdShowPage);
 	if ((showPage == thi_Last) && (lastPageId != thi_Last))

--- a/src/ConEmu/OptionsClass.cpp
+++ b/src/ConEmu/OptionsClass.cpp
@@ -1745,7 +1745,7 @@ LRESULT CSettings::OnPage(LPNMHDR phdr)
 void CSettings::Dialog(int IdShowPage /*= 0*/)
 {
 	const TabHwndIndex lastPageId = gpSetCls->m_LastActivePageId;
-	TabHwndIndex showPage;
+	TabHwndIndex showPage = thi_Last;
 	
 	if (!ghOpWnd || !IsWindow(ghOpWnd))
 	{
@@ -1781,7 +1781,6 @@ void CSettings::Dialog(int IdShowPage /*= 0*/)
 
 	apiShowWindow(ghOpWnd, SW_SHOWNORMAL);
 
-	showPage = thi_Last;
 	if (IdShowPage)
 		showPage = gpSetCls->GetPageIdByDialogId(IdShowPage);
 	if ((showPage == thi_Last) && (lastPageId != thi_Last))

--- a/src/ConEmu/RealConsole.cpp
+++ b/src/ConEmu/RealConsole.cpp
@@ -16384,13 +16384,15 @@ bool CRealConsole::DetachRCon(bool bPosted /*= false*/, bool bSendCloseConsole /
 
 	LogString(L"CRealConsole::Detach");
 
+	SIZE cellSize;
+
 	if (InRecreate())
 	{
 		LogString(L"CRealConsole::Detach - Restricted, InRecreate!");
 		goto wrap;
 	}
 
-	SIZE cellSize = mp_VCon->GetCellSize();
+	cellSize = mp_VCon->GetCellSize();
 
 	if (m_ChildGui.hGuiWnd)
 	{

--- a/src/ConEmu/RealConsole.cpp
+++ b/src/ConEmu/RealConsole.cpp
@@ -16384,7 +16384,7 @@ bool CRealConsole::DetachRCon(bool bPosted /*= false*/, bool bSendCloseConsole /
 
 	LogString(L"CRealConsole::Detach");
 
-	SIZE cellSize;
+	SIZE cellSize = {};
 
 	if (InRecreate())
 	{

--- a/src/ConEmuCD/ConsoleMain.cpp
+++ b/src/ConEmuCD/ConsoleMain.cpp
@@ -4707,7 +4707,7 @@ int ExitWaitForKey(DWORD vkKeys, LPCWSTR asConfirm, BOOL abNewLine, BOOL abDontS
 	PRINT_COMSPEC(L"Finalizing. gbInShutdown=%i\n", gbInShutdown);
 	GetNumberOfConsoleInputEvents(hIn, &nPostFlush);
 
-	DWORD nStartTick = GetTickCount(), nDelta = 0;
+	DWORD nStartTick = 0, nDelta = 0;
 	
 	if (gbInShutdown)
 		goto wrap; // Event закрытия мог припоздниться
@@ -4720,7 +4720,7 @@ int ExitWaitForKey(DWORD vkKeys, LPCWSTR asConfirm, BOOL abNewLine, BOOL abDontS
 		_wprintf(asConfirm);
 	}
 
-	nStartTick = GetTickCount(), nDelta = 0;
+	nStartTick = GetTickCount();
 
 	while (TRUE)
 	{

--- a/src/ConEmuCD/ConsoleMain.cpp
+++ b/src/ConEmuCD/ConsoleMain.cpp
@@ -4707,6 +4707,8 @@ int ExitWaitForKey(DWORD vkKeys, LPCWSTR asConfirm, BOOL abNewLine, BOOL abDontS
 	PRINT_COMSPEC(L"Finalizing. gbInShutdown=%i\n", gbInShutdown);
 	GetNumberOfConsoleInputEvents(hIn, &nPostFlush);
 
+	DWORD nStartTick = GetTickCount(), nDelta = 0;
+	
 	if (gbInShutdown)
 		goto wrap; // Event закрытия мог припоздниться
 
@@ -4718,7 +4720,7 @@ int ExitWaitForKey(DWORD vkKeys, LPCWSTR asConfirm, BOOL abNewLine, BOOL abDontS
 		_wprintf(asConfirm);
 	}
 
-	DWORD nStartTick = GetTickCount(), nDelta = 0;
+	nStartTick = GetTickCount(), nDelta = 0;
 
 	while (TRUE)
 	{

--- a/src/ConEmuHk/InjectsBootstrap.h
+++ b/src/ConEmuHk/InjectsBootstrap.h
@@ -67,6 +67,7 @@ int InjectHookDLL(PROCESS_INFORMATION pi, InjectHookFunctions* pfn /*UINT_PTR fn
 	//GetVersionEx(&osv);
 	//DWORD nOsVer = (osv.dwMajorVersion << 8) | (osv.dwMinorVersion & 0xFF);
 
+	PBYTE ptr_jne = nullptr;
 
 	if (ptrAllocated)
 		*ptrAllocated = 0;
@@ -301,8 +302,6 @@ int InjectHookDLL(PROCESS_INFORMATION pi, InjectHookFunctions* pfn /*UINT_PTR fn
 	*ip.pB++ = 0x15;
 	*ip.pI   = -(int)(ip.pB + 4 - code - 16);  ip.pI++; // -- pointer to procedure address // GCC do the INC before rvalue eval
 	#endif
-
-	PBYTE ptr_jne = nullptr;
 
 	// Due to ASLR of Kernel32.dll in Windows 8 RC x64 we need this workaround
 	// JIC expanded to Windows 7 too.

--- a/src/common/CmdLine.cpp
+++ b/src/common/CmdLine.cpp
@@ -710,6 +710,7 @@ bool IsNeedCmd(BOOL bRootCmd, LPCWSTR asCmdLine, CEStr &szExe,
 	int nLastChar;
 	#ifdef _DEBUG
 	CmdArg szDbgFirst;
+	bool bIsBatch = false;
 	#endif
 
 	if (!asCmdLine || !*asCmdLine)
@@ -720,7 +721,6 @@ bool IsNeedCmd(BOOL bRootCmd, LPCWSTR asCmdLine, CEStr &szExe,
 
 	#ifdef _DEBUG
 	// Это минимальные проверки, собственно к коду - не относятся
-	bool bIsBatch = false;
 	{
 		NextArg(asCmdLine, szDbgFirst);
 		LPCWSTR psz = PointToExt(szDbgFirst);


### PR DESCRIPTION
Jumping to a label (`goto`) should not skip initialization of local objects.
