### PR TITLE
Disabling annoying "Injecting hooks into ... FAILED" messages

### DIFF
--- a/src/ConEmuCD/Actions.cpp
+++ b/src/ConEmuCD/Actions.cpp
@@ -232,7 +232,7 @@ int DoInjectHooks(LPWSTR asCmdArg)
 		{
 			return CERR_HOOKS_WAS_SET;
 		}
-
+#ifdef SHOW_INJECT_MSGBOX
 		// Ошибку (пока во всяком случае) лучше показать, для отлова возможных проблем
 		DWORD nErrCode = GetLastError();
 		//_ASSERTE(iHookRc == 0); -- ассерт не нужен, есть MsgBox
@@ -240,6 +240,7 @@ int DoInjectHooks(LPWSTR asCmdArg)
 		swprintf_c(szTitle, L"ConEmuC[%u], PID=%u", WIN3264TEST(32,64), GetCurrentProcessId());
 		swprintf_c(szDbgMsg, L"ConEmuC.X, PID=%u\nInjecting hooks into PID=%u\nFAILED, code=%i:0x%08X", GetCurrentProcessId(), pi.dwProcessId, iHookRc, nErrCode);
 		MessageBoxW(NULL, szDbgMsg, szTitle, MB_SYSTEMMODAL);
+#endif		
 	}
 	else
 	{

--- a/src/ConEmuCD/ConsoleMain.cpp
+++ b/src/ConEmuCD/ConsoleMain.cpp
@@ -1844,7 +1844,8 @@ int __stdcall ConsoleMain3(int anWorkMode/*0-Server&ComSpec,1-AltServer,2-Reserv
 					// Теперь ставим хуки
 					iHookRc = InjectHooks(pi, gbLogProcess);
 				}
-
+				
+#ifdef SHOW_INJECT_MSGBOX
 				if (iHookRc != CIH_OK/*0*/)
 				{
 					DWORD nErrCode = GetLastError();
@@ -1854,7 +1855,8 @@ int __stdcall ConsoleMain3(int anWorkMode/*0-Server&ComSpec,1-AltServer,2-Reserv
 					swprintf_c(szDbgMsg, L"ConEmuC.M, PID=%u\nInjecting hooks into PID=%u\nFAILED, code=%i:0x%08X", GetCurrentProcessId(), pi.dwProcessId, iHookRc, nErrCode);
 					MessageBoxW(NULL, szDbgMsg, szTitle, MB_SYSTEMMODAL);
 				}
-
+#endif
+				
 				if (gbUseDosBox)
 				{
 					// Если запустился - то сразу добавим в список процессов (хотя он и не консольный)

--- a/src/ConEmuHk/ShellProcessor.cpp
+++ b/src/ConEmuHk/ShellProcessor.cpp
@@ -3168,6 +3168,7 @@ void CShellProc::RunInjectHooks(LPCWSTR asFrom, PROCESS_INFORMATION *lpPI)
 		(m_SrvMapping.cbSize && (m_SrvMapping.nLoggingType == glt_Processes)),
 		pszDllDir);
 
+#ifdef SHOW_INJECT_MSGBOX
 	if (iHookRc != CIH_OK/*0*/)
 	{
 		DWORD nErrCode = GetLastError();
@@ -3180,6 +3181,7 @@ void CShellProc::RunInjectHooks(LPCWSTR asFrom, PROCESS_INFORMATION *lpPI)
 			gsExeName, GetCurrentProcessId(), lpPI->dwProcessId, iHookRc, nErrCode);
 		GuiMessageBox(NULL, szDbgMsg, szTitle, MB_SYSTEMMODAL);
 	}
+#endif	
 
 	// Release process, it called was not set CREATE_SUSPENDED flag
 	if (!mb_WasSuspended)


### PR DESCRIPTION
Disabling annoying "Injecting hooks into ... FAILED" messages unless SHOW_INJECT_MSGBOX is defined.