### PR TITLE
Fixed formatting for "Some links" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ See [Release/ConEmu/License.txt](https://github.com/Maximus5/ConEmu/blob/master/
 
 
 ## Some links
-Wiki: https://conemu.github.io/en/TableOfContents.html
-What's new: https://conemu.github.io/en/Whats_New.html
-Release stages: https://conemu.github.io/en/StableVsPreview.html
-Donate this project: <a ref="https://conemu.github.io/donate.html" rel="nofollow">https://conemu.github.io/donate.html</a>
+* Wiki: https://conemu.github.io/en/TableOfContents.html
+* What's new: https://conemu.github.io/en/Whats_New.html
+* Release stages: https://conemu.github.io/en/StableVsPreview.html
+* Donate this project: <a ref="https://conemu.github.io/donate.html" rel="nofollow">https://conemu.github.io/donate.html</a>
 
 
 


### PR DESCRIPTION
I've noticed that the links list is on one line, and when I checked the source, I found that they're on their own separate lines. Because how Markdown interprets that, I've made them into the bullet-pointed list.