### PR TITLE
gh-2243: Fix arrow key issue in cygwin pseudo console.

### DIFF
--- a/src/ConEmuCD/Queue.cpp
+++ b/src/ConEmuCD/Queue.cpp
@@ -677,6 +677,7 @@ BOOL SendConsoleEvent(INPUT_RECORD* pr, UINT nCount)
 	InputLogger::Log(InputLogger::Event::evt_WriteConInput, nCount);
 
 	HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE); // тут был ghConIn
+#if 0 // The code below disturbs reconstruction of special keys (such as arraw keys) events in pseudo console.
 	// Strange VIM reaction on xterm-keypresses
 	if ((nCount > 2) && (nCount <= 32) && (pr->EventType == KEY_EVENT) && (pr->Event.KeyEvent.wVirtualKeyCode == VK_ESCAPE))
 	{
@@ -692,6 +693,7 @@ BOOL SendConsoleEvent(INPUT_RECORD* pr, UINT nCount)
 		}
 	}
 	else
+#endif
 	{
 		fSuccess = WriteConsoleInput(hIn, pr, nCount, &cbWritten);
 	}

--- a/src/common/InQueue.cpp
+++ b/src/common/InQueue.cpp
@@ -164,7 +164,17 @@ BOOL InQueue::ReadInputQueue(INPUT_RECORD *prs, DWORD *pCount, BOOL bNoRemove /*
 		}
 
 		if (pSrc == this->pInputQueueEnd)
+		{
 			pSrc = this->pInputQueue;
+			pEnd = this->pInputQueueWrite;
+			while (n && pSrc < pEnd)
+			{
+				_ASSERTE(pSrc->EventType != 0);
+				*pDst = *pSrc; nCount++; pSrc++;
+				InterlockedDecrement(&nUsedLen);
+				n--; pDst++;
+			}
+		}
 
 		TODO("Доделать чтение начала буфера, если считали его конец");
 		//
@@ -195,7 +205,7 @@ BOOL InQueue::GetNumberOfBufferEvents()
 		if (pSrc == this->pInputQueueEnd)
 		{
 			pSrc = this->pInputQueue;
-			pEnd = (this->pInputQueueRead < this->pInputQueueWrite) ? this->pInputQueueWrite : this->pInputQueueEnd;
+			pEnd = this->pInputQueueWrite;
 
 			while(pSrc < pEnd)
 			{

--- a/src/common/InQueue_test.cpp
+++ b/src/common/InQueue_test.cpp
@@ -99,12 +99,13 @@ TEST(InQueue, ReadWrite)
 	readRecords.resize(8);
 	EXPECT_EQ(readRecords, writeRecords);
 
-	// Now, ReadInputQueue() reads events even if data is wrapped over end of queue.
+	// At the moment buffer has 1 record before end pointer, and it's actually empty
 	EXPECT_TRUE(queue.IsInputQueueEmpty());
 	EXPECT_TRUE(queue.WriteInputQueue(&writeRecords[0], false, static_cast<DWORD>(writeRecords.size())));
 	EXPECT_FALSE(queue.IsInputQueueEmpty());
 	EXPECT_EQ(queue.GetNumberOfBufferEvents(), 8);
 	readRecords.resize(10);
+	// Now, ReadInputQueue() reads events even if data is wrapped over the end of queue.
 	EXPECT_TRUE(queue.ReadInputQueue(&readRecords[0], &(readCount = 8), false));
 	EXPECT_EQ(readCount, 8);
 	EXPECT_TRUE(queue.IsInputQueueEmpty());

--- a/src/common/InQueue_test.cpp
+++ b/src/common/InQueue_test.cpp
@@ -99,16 +99,14 @@ TEST(InQueue, ReadWrite)
 	readRecords.resize(8);
 	EXPECT_EQ(readRecords, writeRecords);
 
-	// At the moment buffer has 1 record before end pointer, and it's actually empty
+	// Now, ReadInputQueue() reads events even if data is wrapped over end of queue.
 	EXPECT_TRUE(queue.IsInputQueueEmpty());
 	EXPECT_TRUE(queue.WriteInputQueue(&writeRecords[0], false, static_cast<DWORD>(writeRecords.size())));
 	EXPECT_FALSE(queue.IsInputQueueEmpty());
+	EXPECT_TRUE(queue.GetNumberOfBufferEvents(), 8);
 	readRecords.resize(10);
 	EXPECT_TRUE(queue.ReadInputQueue(&readRecords[0], &(readCount = 8), false));
-	EXPECT_EQ(readCount, 1); // this should be fixed by finish reading from the buffer start
-	EXPECT_FALSE(queue.IsInputQueueEmpty());
-	EXPECT_TRUE(queue.ReadInputQueue(&readRecords[1], &(readCount = 8), false));
-	EXPECT_EQ(readCount, 7);
+	EXPECT_EQ(readCount, 8);
 	EXPECT_TRUE(queue.IsInputQueueEmpty());
 	readRecords.resize(8);
 	EXPECT_EQ(readRecords, writeRecords);

--- a/src/common/InQueue_test.cpp
+++ b/src/common/InQueue_test.cpp
@@ -103,7 +103,7 @@ TEST(InQueue, ReadWrite)
 	EXPECT_TRUE(queue.IsInputQueueEmpty());
 	EXPECT_TRUE(queue.WriteInputQueue(&writeRecords[0], false, static_cast<DWORD>(writeRecords.size())));
 	EXPECT_FALSE(queue.IsInputQueueEmpty());
-	EXPECT_TRUE(queue.GetNumberOfBufferEvents(), 8);
+	EXPECT_EQ(queue.GetNumberOfBufferEvents(), 8);
 	readRecords.resize(10);
 	EXPECT_TRUE(queue.ReadInputQueue(&readRecords[0], &(readCount = 8), false));
 	EXPECT_EQ(readCount, 8);


### PR DESCRIPTION
If windows native app (such as vim, gnuplot, etc.) is started in
pseudo console in cygwin pty, arrow keys do not work. The cause
is as follows.

Cygwin 3.1.7, console handler uses xterm mode enabled. As a result,
arrow keys are translated to escape sequences such as "ESC[A",
"ESC[B", etc. When script command or cygwin-connector is started,
pty is opened. If windows native app is executed in pty, pseudo
console is activated. Pseudo console reconstructs escape sequences
"ESC[A" etc. to an arrow key event. However, if the escape sequence
is divided into multiple read, pseudo console fails to reconstruct
them.

This patch fixes the isseu.