### PR TITLE
path containing %DOCKER_TOOLBOX_INSTALL_PATH% have to be quoted

### DIFF
--- a/src/ConEmu/OptionsFast.cpp
+++ b/src/ConEmu/OptionsFast.cpp
@@ -2674,7 +2674,7 @@ static void CreateDockerTask()
 			// "%DOCKER_TOOLBOX_INSTALL_PATH%\\docker-quickstart-terminal.ico"
 			// but it's displayed badly in our tabs at the moment
 			L"/dir \"%DOCKER_TOOLBOX_INSTALL_PATH%\" /icon \"%DOCKER_TOOLBOX_INSTALL_PATH%\\docker.exe\"",
-			L"%DOCKER_TOOLBOX_INSTALL_PATH%\\..\\Git\\usr\\bin\\bash.exe",
+			L"\"%DOCKER_TOOLBOX_INSTALL_PATH%\\..\\Git\\usr\\bin\\bash.exe\"",
 			L"bash.exe",
 			L"[SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Git_is1:InstallLocation]\\usr\\bin\\bash.exe",
 			L"%ProgramFiles%\\Git\\usr\\bin\\bash.exe", L"%ProgramW6432%\\Git\\usr\\bin\\bash.exe",


### PR DESCRIPTION
Without quotes running default task for "Docker" fails with error: 
```
"C:\Program" is not recognized as an internal or external command,
operable program or batch file.
```