### PR TITLE
Persistent user settings for CMD

### DIFF
--- a/Release/ConEmu/CmdInit.cmd
+++ b/Release/ConEmu/CmdInit.cmd
@@ -1,5 +1,7 @@
-@rem !!! Do not change this file in-place, change its copy instead !!!
-@rem !!!  Otherwise you will lose your settings after next update  !!!
+@rem !!! Do not change this file in-place, otherwise you will lose !!!
+@rem !!! your settings after next update.                          !!!
+@rem !!! Create "%USERPROFILE%\.conemu\CmdInit.cmd" and add your   !!!
+@rem !!! custom settings there.                                    !!!
 
 @echo off
 
@@ -49,6 +51,11 @@ goto :end_git
 rem Set new prompt
 PROMPT %ConEmuPrompt1%%ConEmuPrompt2%%ConEmuPrompt3%
 :end_git
+
+rem User profile additions
+if exist "%USERPROFILE%\.conemu\CmdInit.cmd" (
+    call "%USERPROFILE%\.conemu\CmdInit.cmd"
+    )
 
 rem Support additional batch execution as `{cmd} "path\to\batch.cmd" <arguments>`
 rem Due to parsing rules of cmd.exe last argument must NOT ends with "

--- a/Release/ConEmu/CmdInit_user_sample.cmd
+++ b/Release/ConEmu/CmdInit_user_sample.cmd
@@ -1,0 +1,13 @@
+@rem !!! Sample user specific settings that will persist in upgrade !!!
+@rem !!! Save as "%USERPROFILE%\.conemu\CmdInit.cmd" to activate    !!!
+
+@rem @echo Loading ConEmu user settings...
+@echo off
+
+rem Allow (some) Unicode (https://ss64.com/nt/chcp.html)
+chcp 65001
+
+rem {Shell type} {path} right-angle-quote over two lines and no hostname:
+rem		 CMD C:\Users\Me\Code
+rem		 »
+set PROMPT=$E[m$E[32mCMD$E\$S$E[92m$P$E[90m$_$E[90m»$E[m$S$E]9;12$E\


### PR DESCRIPTION
A sample implementation of #2385. Tested and working on my machine (_Microsoft Windows [Version 10.0.19043.1288]_).

My first thought was to have user settings call at the end of CmdInit, but thinking about the "additional batch execution" section it looked like the safest place to me is before this section.

If this implementation is acceptable I'll see about writing a helper script that creates and places a blank (commented out) user settings file instead of relying on people to follow instructions carefully.