### PR TITLE
return back to Windows 2019 in Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ trigger:
     - daily
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2019'
 
 variables:
   solution: 'src/CE.sln'


### PR DESCRIPTION
Switching back to Windows 2019 an Visual Studio 2019 to fix building of 32-bit version, as Visual Studio 2022 in the newer version of `windows-latest` doesn't include the v141_xp platform toolset.

There is a probability that installing the v141_xp platform toolset in Visual Studio 2022 might not help, as [per this comment](https://stackoverflow.com/questions/49516896/how-to-install-build-tools-for-v141-xp-for-vc-2017#comment124939595_58061539) such configuration successfully builds the binary which doesn't actually run in WinXP. Needs investigation.