### PR TITLE
avoid running pipelines when only documentation files are modified

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master, daily]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
   schedule:
     - cron: '0 0 * * 2'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,12 @@ trigger:
     include:
     - master
     - daily
+  paths:
+    exclude:
+    - '**/*.md'
+    - '*.md'
+    - '**/*.txt'
+    - '*.txt'
 
 pool:
   vmImage: 'windows-2019'


### PR DESCRIPTION
The "duplication" like so
```
    - '**/*.md'
    - '*.md'
```
is needed, because some say that [wilcards in Azure pipelines are buggy](https://stackoverflow.com/questions/62172468/how-can-i-exclude-changes-to-the-pipeline-yaml-file-to-trigger-a-build-i-azure-d#comment126378839_69120338). No confirmation, but I don't want to experiment.