### PR TITLE
Do not emit control characters in title reports

### DIFF
--- a/src/ConEmuCD/ConAnsiImpl.cpp
+++ b/src/ConEmuCD/ConAnsiImpl.cpp
@@ -985,7 +985,7 @@ bool SrvAnsiImpl::ReportString(LPCWSTR asRet)
 	LPCWSTR pc = asRet;
 	for (int i = 0; i < nLen; i++, p++, pc++)
 	{
-		const char ch = (wcschr(UNSAFE_CONSOLE_REPORT_CHARS, *pc) == nullptr) ? *pc : L' ';
+		const char ch = *pc >= 0x20 ? *pc : L' ';
 		p->EventType = KEY_EVENT;
 		p->Event.KeyEvent.bKeyDown = TRUE;
 		p->Event.KeyEvent.wRepeatCount = 1;

--- a/src/ConEmuHk/Ansi.cpp
+++ b/src/ConEmuHk/Ansi.cpp
@@ -2505,7 +2505,7 @@ BOOL CEAnsi::ReportString(LPCWSTR asRet)
 	LPCWSTR pc = asRet;
 	for (size_t i = 0; i < nLen; i++, p++, pc++)
 	{
-		const char ch = (wcschr(UNSAFE_CONSOLE_REPORT_CHARS, *pc) == nullptr) ? *pc : L' ';
+		const char ch = *pc >= 0x20 ? *pc : L' ';
 		p->EventType = KEY_EVENT;
 		p->Event.KeyEvent.bKeyDown = TRUE;
 		p->Event.KeyEvent.wRepeatCount = 1;

--- a/src/common/WConsole.h
+++ b/src/common/WConsole.h
@@ -52,9 +52,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DISABLE_NEWLINE_AUTO_RETURN 0x0008
 #endif
 
-// These keys should not be reported back to console input
-#define UNSAFE_CONSOLE_REPORT_CHARS L"\r\n\t"
-
 struct MY_CONSOLE_SCREEN_BUFFER_INFOEX
 {
 	ULONG      cbSize;


### PR DESCRIPTION
`UNSAFE_CONSOLE_REPORT_CHARS` does not cover everything, it's safer to not emit control characters in the title at all.