### PR TITLE
Added switch term mode hotkey

### DIFF
--- a/src/ConEmu/ConEmu.cpp
+++ b/src/ConEmu/ConEmu.cpp
@@ -2610,6 +2610,18 @@ CConEmuMain::~CConEmuMain()
 }
 #endif
 
+void CConEmuMain::AskChangeTermMode()
+{
+	CVConGuard VCon;
+	if (GetActiveVCon(&VCon) < 0)
+		return;
+	CVirtualConsole *pVCon = VCon.VCon();
+	CRealConsole *pRCon = pVCon->RCon();
+	if (!pRCon) return;
+
+    pRCon ->StartStopTermMode(tmc_TerminalType, cta_Switch);
+}
+
 void CConEmuMain::AskChangeBufferHeight()
 {
 	CVConGuard VCon;

--- a/src/ConEmu/ConEmu.h
+++ b/src/ConEmu/ConEmu.h
@@ -597,6 +597,7 @@ class CConEmuMain
 		int ActiveConNum(); // 0-based
 		int GetConCount(); // количество открытых консолей
 		void AskChangeBufferHeight();
+        void AskChangeTermMode();
 		void AskChangeAlternative();
 		void AttachToDialog();
 		void CheckFocus(LPCWSTR asFrom);

--- a/src/ConEmu/ConEmuCtrl.cpp
+++ b/src/ConEmu/ConEmuCtrl.cpp
@@ -526,6 +526,14 @@ bool CConEmuCtrl::key_MultiBuffer(const ConEmuChord& VkState, bool TestOnly, con
 }
 
 // pRCon may be nullptr
+bool CConEmuCtrl::key_SwitchTermMode(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon)
+{
+    if (TestOnly)
+        return true;
+    gpConEmu->AskChangeTermMode();
+    return true;
+}
+// pRCon may be nullptr
 bool CConEmuCtrl::key_DuplicateRoot(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon)
 {
 	if (!pRCon)

--- a/src/ConEmu/ConEmuCtrl.h
+++ b/src/ConEmu/ConEmuCtrl.h
@@ -106,6 +106,7 @@ public:
 	static bool WINAPI key_MultiRecreate(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_AlternativeBuffer(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_MultiBuffer(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
+    static bool WINAPI key_SwitchTermMode(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_DuplicateRoot(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_DuplicateRootAs(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);
 	static bool WINAPI key_MultiCmd(const ConEmuChord& VkState, bool TestOnly, const ConEmuHotKey* hk, CRealConsole* pRCon);

--- a/src/ConEmu/HotkeyList.cpp
+++ b/src/ConEmu/HotkeyList.cpp
@@ -311,8 +311,8 @@ int ConEmuHotKeyList::AllocateHotkeys()
 		.SetHotKey(VK_PAUSE);
 	Add(vkMultiBuffer,     chk_User,  L"Multi.Scroll",          CConEmuCtrl::key_MultiBuffer)
 		;
-    Add(vkSwitchTermMode,     chk_User,  L"Multi.SwitchTermMode",          CConEmuCtrl::key_SwitchTermMode)
-            ;
+    Add(vkSwitchTermMode,  chk_User,  L"Multi.SwitchTermMode", CConEmuCtrl::key_SwitchTermMode)
+        .SetHotKey('M',VK_CONTROL,VK_SHIFT);
 	Add(vkMultiGroup,      chk_User,  L"Multi.GroupInput"     ).SetMacro(L"GroupInput(0)")
 		.SetHotKey('G', VK_APPS);
 	Add(vkMultiGroupAll,   chk_User,  L"Multi.GroupInputAll"  ).SetMacro(L"GroupInput(3)")

--- a/src/ConEmu/HotkeyList.cpp
+++ b/src/ConEmu/HotkeyList.cpp
@@ -311,6 +311,8 @@ int ConEmuHotKeyList::AllocateHotkeys()
 		.SetHotKey(VK_PAUSE);
 	Add(vkMultiBuffer,     chk_User,  L"Multi.Scroll",          CConEmuCtrl::key_MultiBuffer)
 		;
+    Add(vkSwitchTermMode,     chk_User,  L"Multi.SwitchTermMode",          CConEmuCtrl::key_SwitchTermMode)
+            ;
 	Add(vkMultiGroup,      chk_User,  L"Multi.GroupInput"     ).SetMacro(L"GroupInput(0)")
 		.SetHotKey('G', VK_APPS);
 	Add(vkMultiGroupAll,   chk_User,  L"Multi.GroupInputAll"  ).SetMacro(L"GroupInput(3)")

--- a/src/ConEmu/LngDataHints.h
+++ b/src/ConEmu/LngDataHints.h
@@ -408,6 +408,7 @@ static LngPredefined gsDataHints[] = {
 	{ vkMoveTabRight,          L"Move active tab rightward" },
 	{ vkMultiAltCon,           L"Show alternative console buffer (last command output)" },
 	{ vkMultiBuffer,           L"Switch bufferheight mode" },
+    { vkSwitchTermMode,        L"Switch Terminal Input Mode" },
 	{ vkMultiClose,            L"Close active console" },
 	{ vkMultiCmd,              L"Create new %s console" },
 	{ vkMultiGroup,            L"Group keyboard input for visible splits" },

--- a/src/ConEmu/resource.h
+++ b/src/ConEmu/resource.h
@@ -1352,6 +1352,7 @@
 #define stStartupShellGeneral           3110
 #define tFarHourglass                   3111
 #define vkSetFocusParent                3212
+#define vkSwitchTermMode                4321
 #define IDC_STATIC                      -1
 
 // Next default values for new objects

--- a/src/ConEmu/resource.h
+++ b/src/ConEmu/resource.h
@@ -1352,7 +1352,7 @@
 #define stStartupShellGeneral           3110
 #define tFarHourglass                   3111
 #define vkSetFocusParent                3212
-#define vkSwitchTermMode                4321
+#define vkSwitchTermMode                3220
 #define IDC_STATIC                      -1
 
 // Next default values for new objects


### PR DESCRIPTION
Pull Request for Issue #2544 _(Add hotkey for terminal input modes - Xterm vs Windows)_

In this pull request, I've introduced the Ctrl+Shift+M combination as the default hotkey. My choice was based on a preliminary assessment showing that this combination is not currently employed within ConEmu/Far. The letter "M" was selected to signify "Mode."

I welcome feedback on the chosen hotkey. If there's consensus on a more suitable combination, I'm open to making adjustments.

I've conducted tests on my Windows machine, and the feature operates as intended.

As this is my inaugural contribution to ConEmu, I appreciate any guidance or feedback regarding potential improvements or issues within this pull request.