### PR TITLE
Do not interpret "CSI = u" and "CSI ? u" as DECRC

### DIFF
--- a/src/ConEmuCD/ConAnsiImpl.cpp
+++ b/src/ConEmuCD/ConAnsiImpl.cpp
@@ -1299,13 +1299,15 @@ CSI P s @			Insert P s (Blank) Character(s) (default = 1) (ICH)
 	switch (Code.Action) // case sensitive
 	{
 	case L's':
-		// Save cursor position (can not be nested)
-		XTermSaveRestoreCursor(true);
+		if (Code.PvtLen == 0)
+			// Save cursor position (can not be nested)
+			XTermSaveRestoreCursor(true);
 		break;
 
 	case L'u':
-		// Restore cursor position
-		XTermSaveRestoreCursor(false);
+		if (Code.PvtLen == 0)
+			// Restore cursor position
+			XTermSaveRestoreCursor(false);
 		break;
 
 	case L'H': // Set cursor position (1-based)


### PR DESCRIPTION
Unfortunately fish shell version 4 is broken on ConEmu due to the
use of sequences like

    printf '\x1b[=5u'
    printf '\x1b[?u'

used for the kitty keyboard protocol.

ConEmu treats them like "CSI u" (restore cursor position).

Fix that.

Untested -- I haven't built ConEmu yet, I don't know much
about Windows and I don't know if it's still maintained.
But I'll be happy to test, LMK.
